### PR TITLE
Source code performance

### DIFF
--- a/bypass_url_parser.py
+++ b/bypass_url_parser.py
@@ -122,7 +122,7 @@ class Bypasser:
         # Init object vars
         self.base_curl = []
         self.user_agent_suffix = ""
-        self.curl_items = []
+        self.curl_items = set()
         self.curl_ips = []
         self.bypass_results = defaultdict(defaultdict)
         self.to_retry_items = []
@@ -244,8 +244,7 @@ class Bypasser:
         cmd = [*self.base_curl, target_url]
         item = CurlItem(url_obj, self.base_curl, cmd, bypass_mode="original_request", target_ip=self.url_resolved_ip,
                         encoding=self.encoding, debug=self.debug, ext_logger=self.logger)
-        if item not in self.curl_items:
-            self.curl_items.append(item)
+        self.curl_items.add(item)
 
         # [http_methods] - Custom request methods (-X)
         if any(mode in ["all", "http_methods"] for mode in self.current_bypass_modes):
@@ -253,8 +252,7 @@ class Bypasser:
                 cmd = [*self.base_curl, "-X", internal_http_method, target_url]
                 item = CurlItem(url_obj, self.base_curl, cmd, bypass_mode="http_methods", encoding=self.encoding,
                                 target_ip=self.url_resolved_ip, debug=self.debug, ext_logger=self.logger)
-                if item not in self.curl_items:
-                    self.curl_items.append(item)
+                self.curl_items.add(item)
 
         # [http_versions] - Tests the url with all http versions supported by curl
         if any(mode in ["all", "http_versions"] for mode in self.current_bypass_modes):
@@ -262,8 +260,7 @@ class Bypasser:
                 cmd = [*self.get_curl_base(forced_http_version=http_version), target_url]
                 item = CurlItem(url_obj, self.base_curl, cmd, bypass_mode="http_versions", encoding=self.encoding,
                                 target_ip=self.url_resolved_ip, debug=self.debug, ext_logger=self.logger)
-                if item not in self.curl_items:
-                    self.curl_items.append(item)
+                self.curl_items.add(item)
 
         # [http_headers_method] - Custom methods
         if any(mode in ["all", "http_headers_method"] for mode in self.current_bypass_modes):
@@ -272,8 +269,7 @@ class Bypasser:
                     cmd = [*self.base_curl, "-H", f"{header_http_method}: {internal_http_method}", target_url]
                     item = CurlItem(url_obj, self.base_curl, cmd, bypass_mode="http_headers_method", debug=self.debug,
                                     target_ip=self.url_resolved_ip, encoding=self.encoding, ext_logger=self.logger)
-                    if item not in self.curl_items:
-                        self.curl_items.append(item)
+                    self.curl_items.add(item)
 
         # [http_headers_ip] - Custom host injection headers
         if any(mode in ["all", "http_headers_ip"] for mode in self.current_bypass_modes):
@@ -296,8 +292,7 @@ class Bypasser:
             for command in commands:
                 item = CurlItem(url_obj, self.base_curl, list(command), bypass_mode="http_headers_ip", debug=self.debug,
                                 target_ip=self.url_resolved_ip, encoding=self.encoding, ext_logger=self.logger)
-                if item not in self.curl_items:
-                    self.curl_items.append(item)
+                self.curl_items.add(item)
 
         # [http_headers_scheme] - Custom scheme rewrite with X-Forwarded-Scheme
         if any(mode in ["all", "http_headers_scheme"] for mode in self.current_bypass_modes):
@@ -321,8 +316,7 @@ class Bypasser:
                 item = CurlItem(url_obj, self.base_curl, list(command), bypass_mode="http_headers_scheme",
                                 target_ip=self.url_resolved_ip, encoding=self.encoding, debug=self.debug,
                                 ext_logger=self.logger)
-                if item not in self.curl_items:
-                    self.curl_items.append(item)
+                self.curl_items.add(item)
 
         # [http_headers_port] - Custom port rewrite
         if any(mode in ["all", "http_headers_port"] for mode in self.current_bypass_modes):
@@ -341,8 +335,7 @@ class Bypasser:
                     item = CurlItem(url_obj, self.base_curl, list(command), bypass_mode="http_headers_port",
                                     target_ip=self.url_resolved_ip, encoding=self.encoding, debug=self.debug,
                                     ext_logger=self.logger)
-                    if item not in self.curl_items:
-                        self.curl_items.append(item)
+                    self.curl_items.add(item)
 
         # [mid_paths] - Custom paths with extra-mid-slash
         if any(mode in ["all", "mid_paths"] for mode in self.current_bypass_modes):
@@ -361,8 +354,7 @@ class Bypasser:
             for command in commands:
                 item = CurlItem(url_obj, self.base_curl, list(command), bypass_mode="mid_paths", debug=self.debug,
                                 target_ip=self.url_resolved_ip, encoding=self.encoding, ext_logger=self.logger)
-                if item not in self.curl_items:
-                    self.curl_items.append(item)
+                self.curl_items.add(item)
 
         # [end_paths] - Add suffix
         if any(mode in ["all", "end_paths"] for mode in self.current_bypass_modes):
@@ -384,8 +376,7 @@ class Bypasser:
                 for command in commands:
                     item = CurlItem(url_obj, self.base_curl, list(command), bypass_mode="end_paths", debug=self.debug,
                                     target_ip=self.url_resolved_ip, encoding=self.encoding, ext_logger=self.logger)
-                    if item not in self.curl_items:
-                        self.curl_items.append(item)
+                    self.curl_items.add(item)
 
         # Char substitution (character-by-character) bypasses
         abc_indexes = [span.start() for span in re.finditer(r"[a-zA-Z]", base_path)]
@@ -397,8 +388,7 @@ class Bypasser:
                 cmd = [*self.base_curl, f"{base_url}{base_path[:abc_index]}{char_case}{base_path[abc_index + 1:]}"]
                 item = CurlItem(url_obj, self.base_curl, cmd, bypass_mode="case_substitution", encoding=self.encoding,
                                 target_ip=self.url_resolved_ip, debug=self.debug, ext_logger=self.logger)
-                if item not in self.curl_items:
-                    self.curl_items.append(item)
+                self.curl_items.add(item)
 
             # [char_encode] - Url-Encoding
             if any(mode in ["all", "char_encode"] for mode in self.current_bypass_modes):
@@ -407,8 +397,7 @@ class Bypasser:
                        f"{base_url}{base_path[:abc_index]}%{char_urlencoded}{base_path[abc_index + 1:]}"]
                 item = CurlItem(url_obj, self.base_curl, cmd, bypass_mode="char_encode", encoding=self.encoding,
                                 target_ip=self.url_resolved_ip, debug=self.debug, ext_logger=self.logger)
-                if item not in self.curl_items:
-                    self.curl_items.append(item)
+                self.curl_items.add(item)
 
         # Verbose/debug print
         if self.verbose and not self.dump_payloads:
@@ -428,7 +417,7 @@ class Bypasser:
     def _run_curls(self, items):
         """Call multithread curl commands.
 
-        :param list[CurlItem] items: List of item objects
+        :param set[CurlItem] items: List of item objects
         """
         # Reset progress bar
         self.total = len(items)
@@ -1154,7 +1143,7 @@ class Bypasser:
                 self.dump_payloads, self.urls, self.user_agent, self.verbose, self.debug, self.debug_class)
 
     def __eq__(self, other) -> bool:
-        """Equality test, always use after __hash__ when object compare with ==, or if a match occurs in iterable.
+        """Equality test between objects, returns True if both objects have the same type and same attributes.
 
         :param Bypasser other: Other object to compare with this
         :return: True is same object, else False
@@ -1170,11 +1159,11 @@ class Bypasser:
         return not self.__eq__(other)
 
     def __hash__(self) -> int:
-        """Always used first in iterable object compare (set, list..) if match, call __eq__().
+        """Used to get and store a unique object reference in immutable collections.
 
         :return: Object hash
         """
-        return hash(self.__attrs())
+        return hash(str(self.__dict__))
 
     def __str__(self) -> str:
         out = str()
@@ -1568,7 +1557,7 @@ class CurlItem:
                 self.request_curl_cmd, self.response_raw_output)
 
     def __eq__(self, other: any) -> bool:
-        """Equality test, always use after __hash__ when object compare with ==, or if a match occurs in iterable.
+        """Equality test between objects, returns True if both objects have the same type and same attributes.
 
         :param CurlItem other: Other object to compare with this
         :return: True is same object, else False
@@ -1584,11 +1573,11 @@ class CurlItem:
         return not self.__eq__(other)
 
     def __hash__(self) -> int:
-        """Always used first in iterable object compare (set, list..) if match, call __eq__().
+        """Used to get and store a unique object reference in immutable collections.
 
         :return: Object hash
         """
-        return hash(self.__attrs())
+        return hash(str(self.__dict__))
 
     def __str__(self) -> str:
         out = str()

--- a/bypass_url_parser.py
+++ b/bypass_url_parser.py
@@ -125,7 +125,7 @@ class Bypasser:
         self.curl_items = set()
         self.curl_ips = []
         self.bypass_results = defaultdict(defaultdict)
-        self.to_retry_items = []
+        self.to_retry_items = set()
         self.clean_output = ""
         self.pbar_queue = Queue(maxsize=1)
         self.url_resolved_ip = ""
@@ -485,17 +485,14 @@ class Bypasser:
                 item.force_http_version("1.1")
 
                 # Add modified item in retry list
-                if item not in self.to_retry_items:
-                    self.to_retry_items.append(item)
+                self.to_retry_items.add(item)
             else:
-                if item not in self.to_retry_items:
-                    self.to_retry_items.append(item)
+                self.to_retry_items.add(item)
 
         except subprocess.TimeoutExpired as e:
             if self.verbose:
                 self.logger.warning(f"command '{e.cmd}' timed out: {e.output}")
-            if item not in self.to_retry_items:
-                self.to_retry_items.append(item)
+            self.to_retry_items.add(item)
 
     def _save_results(self, url_obj):
         if self.save_level != self.SaveLevel.NONE:

--- a/bypass_url_parser.py
+++ b/bypass_url_parser.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+# noinspection HttpUrlsUsage
 """Bypass Url Parser, made with love by @TheLaluka
 A tool that tests MANY url bypasses to reach a 40X protected page.
 
@@ -417,7 +418,7 @@ class Bypasser:
         # Not doing for now, so many curls already... :)
         return
 
-    def _progress_bar_callback(self, *args):
+    def _progress_bar_callback(self, *args: any):
         self.iteration = self.pbar_queue.get(timeout=10)  # out =>
         # Log every 50 completed requests
         if self.iteration % 50 == 0:
@@ -1158,7 +1159,7 @@ class Bypasser:
         :param Bypasser other: Other object to compare with this
         :return: True is same object, else False
         """
-        return isinstance(other, self.__class__) and self.__attrs() == other.__attrs()
+        return other.__class__ == Bypasser and self.__dict__ == other.__dict__
 
     def __ne__(self, other) -> bool:
         """Define a non-equality test.
@@ -1220,7 +1221,7 @@ class CurlItem:
     REGEX_STATUS_CODE = re.compile(r"HTTP.*\s+(\d+)\s+\w+", re.IGNORECASE)
     REGEX_CONTENT_LENGTH = re.compile(r"Content-Length:\s+(\d+)", re.IGNORECASE)
     REGEX_CONTENT_TYPE = re.compile(r"Content-Type:\s+(\w+/\w+)", re.IGNORECASE)
-    REGEX_HTTP_VERSION = re.compile(r"(?!--)http[\w\d.-]*(?<! )", re.IGNORECASE)
+    REGEX_HTTP_VERSION = re.compile(r"(?!--)http[\w.-]*(?<! )", re.IGNORECASE)
     REGEX_REDIRECT_URL = re.compile(r"Location:\s+(.*)", re.IGNORECASE)
     REGEX_SERVER_TYPE = re.compile(r"Server:\s+(.*)", re.IGNORECASE)
     REGEX_TITLE = re.compile(r"<title>(.*)</title>", re.IGNORECASE)
@@ -1566,13 +1567,13 @@ class CurlItem:
         return (self.target_url, self.target_ip, self.bypass_mode, self.curl_base_options,
                 self.request_curl_cmd, self.response_raw_output)
 
-    def __eq__(self, other) -> bool:
+    def __eq__(self, other: any) -> bool:
         """Equality test, always use after __hash__ when object compare with ==, or if a match occurs in iterable.
 
         :param CurlItem other: Other object to compare with this
         :return: True is same object, else False
         """
-        return isinstance(other, self.__class__) and self.__attrs() == other.__attrs()
+        return other.__class__ == CurlItem and self.__dict__ == other.__dict__
 
     def __ne__(self, other) -> bool:
         """Define a non-equality test.

--- a/tests-history/bup-payloads-2022-10-06.lst
+++ b/tests-history/bup-payloads-2022-10-06.lst
@@ -1,0 +1,3046 @@
+
+Bypasser has generated 3044 payloads for 'http://127.0.0.1:8000/foo/bar' url:
+[case_substitution] http://127.0.0.1:8000/Foo/bar
+[case_substitution] http://127.0.0.1:8000/fOo/bar
+[case_substitution] http://127.0.0.1:8000/foO/bar
+[case_substitution] http://127.0.0.1:8000/foo/Bar
+[case_substitution] http://127.0.0.1:8000/foo/bAr
+[case_substitution] http://127.0.0.1:8000/foo/baR
+[char_encode] http://127.0.0.1:8000/%66oo/bar
+[char_encode] http://127.0.0.1:8000/f%6fo/bar
+[char_encode] http://127.0.0.1:8000/fo%6f/bar
+[char_encode] http://127.0.0.1:8000/foo/%62ar
+[char_encode] http://127.0.0.1:8000/foo/b%61r
+[char_encode] http://127.0.0.1:8000/foo/ba%72
+[end_paths] http://127.0.0.1:8000/foo/bar#
+[end_paths] http://127.0.0.1:8000/foo/bar#/
+[end_paths] http://127.0.0.1:8000/foo/bar#/./
+[end_paths] http://127.0.0.1:8000/foo/bar#/.//
+[end_paths] http://127.0.0.1:8000/foo/bar#//
+[end_paths] http://127.0.0.1:8000/foo/bar%
+[end_paths] http://127.0.0.1:8000/foo/bar%/
+[end_paths] http://127.0.0.1:8000/foo/bar%00
+[end_paths] http://127.0.0.1:8000/foo/bar%00/
+[end_paths] http://127.0.0.1:8000/foo/bar%09
+[end_paths] http://127.0.0.1:8000/foo/bar%09/
+[end_paths] http://127.0.0.1:8000/foo/bar%0A
+[end_paths] http://127.0.0.1:8000/foo/bar%0A/
+[end_paths] http://127.0.0.1:8000/foo/bar%0D
+[end_paths] http://127.0.0.1:8000/foo/bar%0D/
+[end_paths] http://127.0.0.1:8000/foo/bar%20
+[end_paths] http://127.0.0.1:8000/foo/bar%20/
+[end_paths] http://127.0.0.1:8000/foo/bar%23
+[end_paths] http://127.0.0.1:8000/foo/bar%23/
+[end_paths] http://127.0.0.1:8000/foo/bar%26
+[end_paths] http://127.0.0.1:8000/foo/bar%26/
+[end_paths] http://127.0.0.1:8000/foo/bar%3f
+[end_paths] http://127.0.0.1:8000/foo/bar%3f/
+[end_paths] http://127.0.0.1:8000/foo/bar%61
+[end_paths] http://127.0.0.1:8000/foo/bar%61/
+[end_paths] http://127.0.0.1:8000/foo/bar&
+[end_paths] http://127.0.0.1:8000/foo/bar&/
+[end_paths] http://127.0.0.1:8000/foo/bar-
+[end_paths] http://127.0.0.1:8000/foo/bar-/
+[end_paths] http://127.0.0.1:8000/foo/bar.
+[end_paths] http://127.0.0.1:8000/foo/bar..;
+[end_paths] http://127.0.0.1:8000/foo/bar..;/
+[end_paths] http://127.0.0.1:8000/foo/bar..\;
+[end_paths] http://127.0.0.1:8000/foo/bar..\;/
+[end_paths] http://127.0.0.1:8000/foo/bar./
+[end_paths] http://127.0.0.1:8000/foo/bar.//
+[end_paths] http://127.0.0.1:8000/foo/bar.html
+[end_paths] http://127.0.0.1:8000/foo/bar.html/
+[end_paths] http://127.0.0.1:8000/foo/bar.json
+[end_paths] http://127.0.0.1:8000/foo/bar.json/
+[end_paths] http://127.0.0.1:8000/foo/bar.random
+[end_paths] http://127.0.0.1:8000/foo/bar.random/
+[end_paths] http://127.0.0.1:8000/foo/bar.svc
+[end_paths] http://127.0.0.1:8000/foo/bar.svc/
+[end_paths] http://127.0.0.1:8000/foo/bar.svc?wsdl
+[end_paths] http://127.0.0.1:8000/foo/bar.svc?wsdl/
+[end_paths] http://127.0.0.1:8000/foo/bar.wsdl
+[end_paths] http://127.0.0.1:8000/foo/bar.wsdl/
+[end_paths] http://127.0.0.1:8000/foo/bar/
+[end_paths] http://127.0.0.1:8000/foo/bar/#
+[end_paths] http://127.0.0.1:8000/foo/bar/#/
+[end_paths] http://127.0.0.1:8000/foo/bar/#/./
+[end_paths] http://127.0.0.1:8000/foo/bar/#/.//
+[end_paths] http://127.0.0.1:8000/foo/bar/#//
+[end_paths] http://127.0.0.1:8000/foo/bar/%
+[end_paths] http://127.0.0.1:8000/foo/bar/%/
+[end_paths] http://127.0.0.1:8000/foo/bar/%00
+[end_paths] http://127.0.0.1:8000/foo/bar/%00/
+[end_paths] http://127.0.0.1:8000/foo/bar/%09
+[end_paths] http://127.0.0.1:8000/foo/bar/%09/
+[end_paths] http://127.0.0.1:8000/foo/bar/%0A
+[end_paths] http://127.0.0.1:8000/foo/bar/%0A/
+[end_paths] http://127.0.0.1:8000/foo/bar/%0D
+[end_paths] http://127.0.0.1:8000/foo/bar/%0D/
+[end_paths] http://127.0.0.1:8000/foo/bar/%20
+[end_paths] http://127.0.0.1:8000/foo/bar/%20/
+[end_paths] http://127.0.0.1:8000/foo/bar/%23
+[end_paths] http://127.0.0.1:8000/foo/bar/%23/
+[end_paths] http://127.0.0.1:8000/foo/bar/%26
+[end_paths] http://127.0.0.1:8000/foo/bar/%26/
+[end_paths] http://127.0.0.1:8000/foo/bar/%3f
+[end_paths] http://127.0.0.1:8000/foo/bar/%3f/
+[end_paths] http://127.0.0.1:8000/foo/bar/%61
+[end_paths] http://127.0.0.1:8000/foo/bar/%61/
+[end_paths] http://127.0.0.1:8000/foo/bar/&
+[end_paths] http://127.0.0.1:8000/foo/bar/&/
+[end_paths] http://127.0.0.1:8000/foo/bar/-
+[end_paths] http://127.0.0.1:8000/foo/bar/-/
+[end_paths] http://127.0.0.1:8000/foo/bar/.
+[end_paths] http://127.0.0.1:8000/foo/bar/..;
+[end_paths] http://127.0.0.1:8000/foo/bar/..;/
+[end_paths] http://127.0.0.1:8000/foo/bar/..\;
+[end_paths] http://127.0.0.1:8000/foo/bar/..\;/
+[end_paths] http://127.0.0.1:8000/foo/bar/./
+[end_paths] http://127.0.0.1:8000/foo/bar/.//
+[end_paths] http://127.0.0.1:8000/foo/bar/.html
+[end_paths] http://127.0.0.1:8000/foo/bar/.html/
+[end_paths] http://127.0.0.1:8000/foo/bar/.json
+[end_paths] http://127.0.0.1:8000/foo/bar/.json/
+[end_paths] http://127.0.0.1:8000/foo/bar/.random
+[end_paths] http://127.0.0.1:8000/foo/bar/.random/
+[end_paths] http://127.0.0.1:8000/foo/bar/.svc
+[end_paths] http://127.0.0.1:8000/foo/bar/.svc/
+[end_paths] http://127.0.0.1:8000/foo/bar/.svc?wsdl
+[end_paths] http://127.0.0.1:8000/foo/bar/.svc?wsdl/
+[end_paths] http://127.0.0.1:8000/foo/bar/.wsdl
+[end_paths] http://127.0.0.1:8000/foo/bar/.wsdl/
+[end_paths] http://127.0.0.1:8000/foo/bar//
+[end_paths] http://127.0.0.1:8000/foo/bar///
+[end_paths] http://127.0.0.1:8000/foo/bar////
+[end_paths] http://127.0.0.1:8000/foo/bar/0
+[end_paths] http://127.0.0.1:8000/foo/bar/0/
+[end_paths] http://127.0.0.1:8000/foo/bar/1
+[end_paths] http://127.0.0.1:8000/foo/bar/1/
+[end_paths] http://127.0.0.1:8000/foo/bar/?
+[end_paths] http://127.0.0.1:8000/foo/bar/?/
+[end_paths] http://127.0.0.1:8000/foo/bar/??
+[end_paths] http://127.0.0.1:8000/foo/bar/??/
+[end_paths] http://127.0.0.1:8000/foo/bar/???
+[end_paths] http://127.0.0.1:8000/foo/bar/???/
+[end_paths] http://127.0.0.1:8000/foo/bar/?WSDL
+[end_paths] http://127.0.0.1:8000/foo/bar/?WSDL/
+[end_paths] http://127.0.0.1:8000/foo/bar/?debug=1
+[end_paths] http://127.0.0.1:8000/foo/bar/?debug=1/
+[end_paths] http://127.0.0.1:8000/foo/bar/?debug=true
+[end_paths] http://127.0.0.1:8000/foo/bar/?debug=true/
+[end_paths] http://127.0.0.1:8000/foo/bar/?param
+[end_paths] http://127.0.0.1:8000/foo/bar/?param/
+[end_paths] http://127.0.0.1:8000/foo/bar/\/\/
+[end_paths] http://127.0.0.1:8000/foo/bar/\/\//
+[end_paths] http://127.0.0.1:8000/foo/bar/debug
+[end_paths] http://127.0.0.1:8000/foo/bar/debug/
+[end_paths] http://127.0.0.1:8000/foo/bar/false
+[end_paths] http://127.0.0.1:8000/foo/bar/false/
+[end_paths] http://127.0.0.1:8000/foo/bar/null
+[end_paths] http://127.0.0.1:8000/foo/bar/null/
+[end_paths] http://127.0.0.1:8000/foo/bar/true
+[end_paths] http://127.0.0.1:8000/foo/bar/true/
+[end_paths] http://127.0.0.1:8000/foo/bar/~
+[end_paths] http://127.0.0.1:8000/foo/bar/~/
+[end_paths] http://127.0.0.1:8000/foo/bar/°/
+[end_paths] http://127.0.0.1:8000/foo/bar/°//
+[end_paths] http://127.0.0.1:8000/foo/bar0
+[end_paths] http://127.0.0.1:8000/foo/bar0/
+[end_paths] http://127.0.0.1:8000/foo/bar1
+[end_paths] http://127.0.0.1:8000/foo/bar1/
+[end_paths] http://127.0.0.1:8000/foo/bar?
+[end_paths] http://127.0.0.1:8000/foo/bar?/
+[end_paths] http://127.0.0.1:8000/foo/bar??
+[end_paths] http://127.0.0.1:8000/foo/bar??/
+[end_paths] http://127.0.0.1:8000/foo/bar???
+[end_paths] http://127.0.0.1:8000/foo/bar???/
+[end_paths] http://127.0.0.1:8000/foo/bar?WSDL
+[end_paths] http://127.0.0.1:8000/foo/bar?WSDL/
+[end_paths] http://127.0.0.1:8000/foo/bar?debug=1
+[end_paths] http://127.0.0.1:8000/foo/bar?debug=1/
+[end_paths] http://127.0.0.1:8000/foo/bar?debug=true
+[end_paths] http://127.0.0.1:8000/foo/bar?debug=true/
+[end_paths] http://127.0.0.1:8000/foo/bar?param
+[end_paths] http://127.0.0.1:8000/foo/bar?param/
+[end_paths] http://127.0.0.1:8000/foo/bar\/\/
+[end_paths] http://127.0.0.1:8000/foo/bar\/\//
+[end_paths] http://127.0.0.1:8000/foo/bar~
+[end_paths] http://127.0.0.1:8000/foo/bar~/
+[end_paths] http://127.0.0.1:8000/foo/bar°/
+[end_paths] http://127.0.0.1:8000/foo/bar°//
+[http_headers_ip] -H Ali-CDN-Real-IP: * http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Ali-CDN-Real-IP: 0.0.0.0 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Ali-CDN-Real-IP: 0177.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Ali-CDN-Real-IP: 10.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Ali-CDN-Real-IP: 127.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Ali-CDN-Real-IP: 172.17.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Ali-CDN-Real-IP: 192.168.0.2 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Ali-CDN-Real-IP: 192.168.1.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Ali-CDN-Real-IP: 8.8.8.8 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Ali-CDN-Real-IP: localhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Ali-CDN-Real-IP: norealhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Ali-CDN-Real-IP: null http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H CF-Connecting-IP: * http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H CF-Connecting-IP: 0.0.0.0 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H CF-Connecting-IP: 0177.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H CF-Connecting-IP: 10.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H CF-Connecting-IP: 127.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H CF-Connecting-IP: 172.17.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H CF-Connecting-IP: 192.168.0.2 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H CF-Connecting-IP: 192.168.1.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H CF-Connecting-IP: 8.8.8.8 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H CF-Connecting-IP: localhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H CF-Connecting-IP: norealhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H CF-Connecting-IP: null http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Cdn-Real-IP: * http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Cdn-Real-IP: 0.0.0.0 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Cdn-Real-IP: 0177.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Cdn-Real-IP: 10.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Cdn-Real-IP: 127.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Cdn-Real-IP: 172.17.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Cdn-Real-IP: 192.168.0.2 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Cdn-Real-IP: 192.168.1.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Cdn-Real-IP: 8.8.8.8 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Cdn-Real-IP: localhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Cdn-Real-IP: norealhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Cdn-Real-IP: null http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Cdn-Src-IP: * http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Cdn-Src-IP: 0.0.0.0 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Cdn-Src-IP: 0177.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Cdn-Src-IP: 10.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Cdn-Src-IP: 127.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Cdn-Src-IP: 172.17.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Cdn-Src-IP: 192.168.0.2 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Cdn-Src-IP: 192.168.1.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Cdn-Src-IP: 8.8.8.8 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Cdn-Src-IP: localhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Cdn-Src-IP: norealhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Cdn-Src-IP: null http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Cf-Pseudo-IPv4: * http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Cf-Pseudo-IPv4: 0.0.0.0 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Cf-Pseudo-IPv4: 0177.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Cf-Pseudo-IPv4: 10.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Cf-Pseudo-IPv4: 127.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Cf-Pseudo-IPv4: 172.17.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Cf-Pseudo-IPv4: 192.168.0.2 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Cf-Pseudo-IPv4: 192.168.1.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Cf-Pseudo-IPv4: 8.8.8.8 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Cf-Pseudo-IPv4: localhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Cf-Pseudo-IPv4: norealhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Cf-Pseudo-IPv4: null http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Client-IP: * http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Client-IP: 0.0.0.0 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Client-IP: 0177.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Client-IP: 10.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Client-IP: 127.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Client-IP: 172.17.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Client-IP: 192.168.0.2 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Client-IP: 192.168.1.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Client-IP: 8.8.8.8 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Client-IP: localhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Client-IP: norealhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Client-IP: null http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Cluster-Client-IP: * http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Cluster-Client-IP: 0.0.0.0 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Cluster-Client-IP: 0177.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Cluster-Client-IP: 10.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Cluster-Client-IP: 127.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Cluster-Client-IP: 172.17.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Cluster-Client-IP: 192.168.0.2 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Cluster-Client-IP: 192.168.1.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Cluster-Client-IP: 8.8.8.8 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Cluster-Client-IP: localhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Cluster-Client-IP: norealhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Cluster-Client-IP: null http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Cluster-IP: * http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Cluster-IP: 0.0.0.0 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Cluster-IP: 0177.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Cluster-IP: 10.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Cluster-IP: 127.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Cluster-IP: 172.17.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Cluster-IP: 192.168.0.2 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Cluster-IP: 192.168.1.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Cluster-IP: 8.8.8.8 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Cluster-IP: localhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Cluster-IP: norealhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Cluster-IP: null http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Connection: * http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Connection: 0.0.0.0 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Connection: 0177.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Connection: 10.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Connection: 127.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Connection: 172.17.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Connection: 192.168.0.2 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Connection: 192.168.1.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Connection: 8.8.8.8 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Connection: localhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Connection: norealhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Connection: null http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Contact: * http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Contact: 0.0.0.0 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Contact: 0177.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Contact: 10.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Contact: 127.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Contact: 172.17.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Contact: 192.168.0.2 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Contact: 192.168.1.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Contact: 8.8.8.8 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Contact: localhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Contact: norealhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Contact: null http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Destination: * http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Destination: 0.0.0.0 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Destination: 0177.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Destination: 10.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Destination: 127.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Destination: 172.17.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Destination: 192.168.0.2 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Destination: 192.168.1.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Destination: 8.8.8.8 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Destination: localhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Destination: norealhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Destination: null http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Fastly-Client-IP: * http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Fastly-Client-IP: 0.0.0.0 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Fastly-Client-IP: 0177.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Fastly-Client-IP: 10.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Fastly-Client-IP: 127.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Fastly-Client-IP: 172.17.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Fastly-Client-IP: 192.168.0.2 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Fastly-Client-IP: 192.168.1.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Fastly-Client-IP: 8.8.8.8 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Fastly-Client-IP: localhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Fastly-Client-IP: norealhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Fastly-Client-IP: null http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Forwarded-For-IP: * http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Forwarded-For-IP: 0.0.0.0 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Forwarded-For-IP: 0177.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Forwarded-For-IP: 10.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Forwarded-For-IP: 127.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Forwarded-For-IP: 172.17.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Forwarded-For-IP: 192.168.0.2 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Forwarded-For-IP: 192.168.1.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Forwarded-For-IP: 8.8.8.8 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Forwarded-For-IP: localhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Forwarded-For-IP: norealhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Forwarded-For-IP: null http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Forwarded-For: * http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Forwarded-For: 0.0.0.0 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Forwarded-For: 0177.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Forwarded-For: 10.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Forwarded-For: 127.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Forwarded-For: 172.17.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Forwarded-For: 192.168.0.2 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Forwarded-For: 192.168.1.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Forwarded-For: 8.8.8.8 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Forwarded-For: localhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Forwarded-For: norealhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Forwarded-For: null http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Forwarded-Host: * http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Forwarded-Host: 0.0.0.0 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Forwarded-Host: 0177.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Forwarded-Host: 10.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Forwarded-Host: 127.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Forwarded-Host: 172.17.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Forwarded-Host: 192.168.0.2 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Forwarded-Host: 192.168.1.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Forwarded-Host: 8.8.8.8 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Forwarded-Host: localhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Forwarded-Host: norealhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Forwarded-Host: null http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Forwarded: by=* http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Forwarded: by=0.0.0.0 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Forwarded: by=0177.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Forwarded: by=10.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Forwarded: by=127.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Forwarded: by=172.17.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Forwarded: by=192.168.0.2 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Forwarded: by=192.168.1.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Forwarded: by=8.8.8.8 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Forwarded: by=localhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Forwarded: by=norealhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Forwarded: by=null http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Forwarded: for=* http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Forwarded: for=0.0.0.0 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Forwarded: for=0177.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Forwarded: for=10.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Forwarded: for=127.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Forwarded: for=172.17.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Forwarded: for=192.168.0.2 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Forwarded: for=192.168.1.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Forwarded: for=8.8.8.8 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Forwarded: for=localhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Forwarded: for=norealhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Forwarded: for=null http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Forwarded: host=* http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Forwarded: host=0.0.0.0 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Forwarded: host=0177.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Forwarded: host=10.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Forwarded: host=127.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Forwarded: host=172.17.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Forwarded: host=192.168.0.2 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Forwarded: host=192.168.1.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Forwarded: host=8.8.8.8 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Forwarded: host=localhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Forwarded: host=norealhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Forwarded: host=null http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Forwarder-For: * http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Forwarder-For: 0.0.0.0 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Forwarder-For: 0177.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Forwarder-For: 10.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Forwarder-For: 127.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Forwarder-For: 172.17.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Forwarder-For: 192.168.0.2 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Forwarder-For: 192.168.1.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Forwarder-For: 8.8.8.8 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Forwarder-For: localhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Forwarder-For: norealhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Forwarder-For: null http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Forwarder-Host: * http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Forwarder-Host: 0.0.0.0 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Forwarder-Host: 0177.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Forwarder-Host: 10.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Forwarder-Host: 127.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Forwarder-Host: 172.17.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Forwarder-Host: 192.168.0.2 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Forwarder-Host: 192.168.1.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Forwarder-Host: 8.8.8.8 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Forwarder-Host: localhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Forwarder-Host: norealhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Forwarder-Host: null http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Forwarder: * http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Forwarder: 0.0.0.0 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Forwarder: 0177.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Forwarder: 10.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Forwarder: 127.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Forwarder: 172.17.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Forwarder: 192.168.0.2 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Forwarder: 192.168.1.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Forwarder: 8.8.8.8 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Forwarder: localhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Forwarder: norealhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Forwarder: null http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Forwarding-For: * http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Forwarding-For: 0.0.0.0 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Forwarding-For: 0177.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Forwarding-For: 10.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Forwarding-For: 127.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Forwarding-For: 172.17.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Forwarding-For: 192.168.0.2 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Forwarding-For: 192.168.1.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Forwarding-For: 8.8.8.8 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Forwarding-For: localhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Forwarding-For: norealhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Forwarding-For: null http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Forwarding-Host: * http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Forwarding-Host: 0.0.0.0 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Forwarding-Host: 0177.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Forwarding-Host: 10.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Forwarding-Host: 127.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Forwarding-Host: 172.17.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Forwarding-Host: 192.168.0.2 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Forwarding-Host: 192.168.1.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Forwarding-Host: 8.8.8.8 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Forwarding-Host: localhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Forwarding-Host: norealhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Forwarding-Host: null http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Forwarding: * http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Forwarding: 0.0.0.0 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Forwarding: 0177.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Forwarding: 10.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Forwarding: 127.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Forwarding: 172.17.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Forwarding: 192.168.0.2 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Forwarding: 192.168.1.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Forwarding: 8.8.8.8 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Forwarding: localhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Forwarding: norealhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Forwarding: null http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H From: * http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H From: 0.0.0.0 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H From: 0177.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H From: 10.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H From: 127.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H From: 172.17.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H From: 192.168.0.2 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H From: 192.168.1.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H From: 8.8.8.8 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H From: localhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H From: norealhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H From: null http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H HTTP-Host: * http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H HTTP-Host: 0.0.0.0 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H HTTP-Host: 0177.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H HTTP-Host: 10.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H HTTP-Host: 127.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H HTTP-Host: 172.17.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H HTTP-Host: 192.168.0.2 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H HTTP-Host: 192.168.1.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H HTTP-Host: 8.8.8.8 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H HTTP-Host: localhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H HTTP-Host: norealhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H HTTP-Host: null http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Host-IP: * http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Host-IP: 0.0.0.0 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Host-IP: 0177.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Host-IP: 10.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Host-IP: 127.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Host-IP: 172.17.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Host-IP: 192.168.0.2 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Host-IP: 192.168.1.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Host-IP: 8.8.8.8 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Host-IP: localhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Host-IP: norealhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Host-IP: null http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Host: * http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Host: 0.0.0.0 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Host: 0177.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Host: 10.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Host: 127.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Host: 172.17.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Host: 192.168.0.2 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Host: 192.168.1.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Host: 8.8.8.8 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Host: localhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Host: norealhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Host: null http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H IP: * http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H IP: 0.0.0.0 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H IP: 0177.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H IP: 10.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H IP: 127.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H IP: 172.17.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H IP: 192.168.0.2 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H IP: 192.168.1.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H IP: 8.8.8.8 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H IP: localhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H IP: norealhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H IP: null http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Incap-Client-IP: * http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Incap-Client-IP: 0.0.0.0 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Incap-Client-IP: 0177.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Incap-Client-IP: 10.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Incap-Client-IP: 127.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Incap-Client-IP: 172.17.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Incap-Client-IP: 192.168.0.2 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Incap-Client-IP: 192.168.1.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Incap-Client-IP: 8.8.8.8 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Incap-Client-IP: localhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Incap-Client-IP: norealhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Incap-Client-IP: null http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Origin-Host: * http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Origin-Host: 0.0.0.0 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Origin-Host: 0177.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Origin-Host: 10.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Origin-Host: 127.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Origin-Host: 172.17.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Origin-Host: 192.168.0.2 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Origin-Host: 192.168.1.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Origin-Host: 8.8.8.8 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Origin-Host: localhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Origin-Host: norealhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Origin-Host: null http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Origin-IP: * http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Origin-IP: 0.0.0.0 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Origin-IP: 0177.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Origin-IP: 10.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Origin-IP: 127.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Origin-IP: 172.17.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Origin-IP: 192.168.0.2 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Origin-IP: 192.168.1.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Origin-IP: 8.8.8.8 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Origin-IP: localhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Origin-IP: norealhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Origin-IP: null http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Origin: * http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Origin: 0.0.0.0 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Origin: 0177.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Origin: 10.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Origin: 127.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Origin: 172.17.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Origin: 192.168.0.2 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Origin: 192.168.1.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Origin: 8.8.8.8 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Origin: localhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Origin: norealhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Origin: null http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Originating-IP: * http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Originating-IP: 0.0.0.0 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Originating-IP: 0177.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Originating-IP: 10.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Originating-IP: 127.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Originating-IP: 172.17.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Originating-IP: 192.168.0.2 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Originating-IP: 192.168.1.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Originating-IP: 8.8.8.8 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Originating-IP: localhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Originating-IP: norealhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Originating-IP: null http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Override-IP: * http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Override-IP: 0.0.0.0 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Override-IP: 0177.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Override-IP: 10.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Override-IP: 127.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Override-IP: 172.17.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Override-IP: 192.168.0.2 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Override-IP: 192.168.1.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Override-IP: 8.8.8.8 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Override-IP: localhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Override-IP: norealhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Override-IP: null http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Profile: * http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Profile: 0.0.0.0 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Profile: 0177.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Profile: 10.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Profile: 127.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Profile: 172.17.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Profile: 192.168.0.2 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Profile: 192.168.1.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Profile: 8.8.8.8 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Profile: localhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Profile: norealhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Profile: null http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Proxy-Client-IP: * http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Proxy-Client-IP: 0.0.0.0 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Proxy-Client-IP: 0177.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Proxy-Client-IP: 10.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Proxy-Client-IP: 127.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Proxy-Client-IP: 172.17.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Proxy-Client-IP: 192.168.0.2 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Proxy-Client-IP: 192.168.1.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Proxy-Client-IP: 8.8.8.8 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Proxy-Client-IP: localhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Proxy-Client-IP: norealhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Proxy-Client-IP: null http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Proxy-Host: * http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Proxy-Host: 0.0.0.0 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Proxy-Host: 0177.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Proxy-Host: 10.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Proxy-Host: 127.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Proxy-Host: 172.17.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Proxy-Host: 192.168.0.2 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Proxy-Host: 192.168.1.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Proxy-Host: 8.8.8.8 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Proxy-Host: localhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Proxy-Host: norealhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Proxy-Host: null http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Proxy-IP: * http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Proxy-IP: 0.0.0.0 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Proxy-IP: 0177.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Proxy-IP: 10.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Proxy-IP: 127.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Proxy-IP: 172.17.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Proxy-IP: 192.168.0.2 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Proxy-IP: 192.168.1.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Proxy-IP: 8.8.8.8 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Proxy-IP: localhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Proxy-IP: norealhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Proxy-IP: null http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Proxy: * http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Proxy: 0.0.0.0 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Proxy: 0177.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Proxy: 10.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Proxy: 127.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Proxy: 172.17.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Proxy: 192.168.0.2 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Proxy: 192.168.1.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Proxy: 8.8.8.8 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Proxy: localhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Proxy: norealhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Proxy: null http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Real-Client-IP: * http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Real-Client-IP: 0.0.0.0 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Real-Client-IP: 0177.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Real-Client-IP: 10.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Real-Client-IP: 127.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Real-Client-IP: 172.17.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Real-Client-IP: 192.168.0.2 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Real-Client-IP: 192.168.1.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Real-Client-IP: 8.8.8.8 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Real-Client-IP: localhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Real-Client-IP: norealhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Real-Client-IP: null http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Real-IP: * http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Real-IP: 0.0.0.0 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Real-IP: 0177.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Real-IP: 10.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Real-IP: 127.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Real-IP: 172.17.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Real-IP: 192.168.0.2 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Real-IP: 192.168.1.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Real-IP: 8.8.8.8 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Real-IP: localhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Real-IP: norealhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Real-IP: null http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Redirect: * http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Redirect: 0.0.0.0 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Redirect: 0177.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Redirect: 10.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Redirect: 127.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Redirect: 172.17.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Redirect: 192.168.0.2 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Redirect: 192.168.1.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Redirect: 8.8.8.8 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Redirect: localhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Redirect: norealhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Redirect: null http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Remote-Addr: * http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Remote-Addr: 0.0.0.0 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Remote-Addr: 0177.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Remote-Addr: 10.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Remote-Addr: 127.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Remote-Addr: 172.17.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Remote-Addr: 192.168.0.2 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Remote-Addr: 192.168.1.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Remote-Addr: 8.8.8.8 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Remote-Addr: localhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Remote-Addr: norealhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Remote-Addr: null http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Remote-Host: * http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Remote-Host: 0.0.0.0 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Remote-Host: 0177.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Remote-Host: 10.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Remote-Host: 127.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Remote-Host: 172.17.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Remote-Host: 192.168.0.2 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Remote-Host: 192.168.1.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Remote-Host: 8.8.8.8 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Remote-Host: localhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Remote-Host: norealhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Remote-Host: null http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Remote-IP: * http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Remote-IP: 0.0.0.0 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Remote-IP: 0177.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Remote-IP: 10.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Remote-IP: 127.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Remote-IP: 172.17.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Remote-IP: 192.168.0.2 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Remote-IP: 192.168.1.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Remote-IP: 8.8.8.8 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Remote-IP: localhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Remote-IP: norealhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Remote-IP: null http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Request-Uri: * http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Request-Uri: 0.0.0.0 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Request-Uri: 0177.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Request-Uri: 10.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Request-Uri: 127.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Request-Uri: 172.17.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Request-Uri: 192.168.0.2 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Request-Uri: 192.168.1.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Request-Uri: 8.8.8.8 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Request-Uri: localhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Request-Uri: norealhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Request-Uri: null http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Server-IP: * http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Server-IP: 0.0.0.0 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Server-IP: 0177.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Server-IP: 10.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Server-IP: 127.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Server-IP: 172.17.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Server-IP: 192.168.0.2 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Server-IP: 192.168.1.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Server-IP: 8.8.8.8 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Server-IP: localhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Server-IP: norealhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Server-IP: null http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Server-Name: * http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Server-Name: 0.0.0.0 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Server-Name: 0177.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Server-Name: 10.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Server-Name: 127.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Server-Name: 172.17.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Server-Name: 192.168.0.2 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Server-Name: 192.168.1.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Server-Name: 8.8.8.8 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Server-Name: localhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Server-Name: norealhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Server-Name: null http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Server: * http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Server: 0.0.0.0 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Server: 0177.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Server: 10.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Server: 127.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Server: 172.17.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Server: 192.168.0.2 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Server: 192.168.1.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Server: 8.8.8.8 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Server: localhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Server: norealhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Server: null http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Source-IP: * http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Source-IP: 0.0.0.0 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Source-IP: 0177.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Source-IP: 10.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Source-IP: 127.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Source-IP: 172.17.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Source-IP: 192.168.0.2 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Source-IP: 192.168.1.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Source-IP: 8.8.8.8 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Source-IP: localhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Source-IP: norealhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Source-IP: null http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H True-Client-IP: * http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H True-Client-IP: 0.0.0.0 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H True-Client-IP: 0177.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H True-Client-IP: 10.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H True-Client-IP: 127.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H True-Client-IP: 172.17.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H True-Client-IP: 192.168.0.2 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H True-Client-IP: 192.168.1.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H True-Client-IP: 8.8.8.8 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H True-Client-IP: localhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H True-Client-IP: norealhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H True-Client-IP: null http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H True-Client: * http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H True-Client: 0.0.0.0 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H True-Client: 0177.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H True-Client: 10.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H True-Client: 127.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H True-Client: 172.17.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H True-Client: 192.168.0.2 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H True-Client: 192.168.1.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H True-Client: 8.8.8.8 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H True-Client: localhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H True-Client: norealhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H True-Client: null http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Via: * http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Via: 0.0.0.0 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Via: 0177.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Via: 10.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Via: 127.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Via: 172.17.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Via: 192.168.0.2 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Via: 192.168.1.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Via: 8.8.8.8 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Via: localhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Via: norealhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Via: null http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H WL-Proxy-Client-IP: * http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H WL-Proxy-Client-IP: 0.0.0.0 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H WL-Proxy-Client-IP: 0177.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H WL-Proxy-Client-IP: 10.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H WL-Proxy-Client-IP: 127.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H WL-Proxy-Client-IP: 172.17.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H WL-Proxy-Client-IP: 192.168.0.2 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H WL-Proxy-Client-IP: 192.168.1.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H WL-Proxy-Client-IP: 8.8.8.8 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H WL-Proxy-Client-IP: localhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H WL-Proxy-Client-IP: norealhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H WL-Proxy-Client-IP: null http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-AppEngine-Trusted-IP-Request: 1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Appengine-User-IP: * http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Appengine-User-IP: 0.0.0.0 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Appengine-User-IP: 0177.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Appengine-User-IP: 10.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Appengine-User-IP: 127.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Appengine-User-IP: 172.17.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Appengine-User-IP: 192.168.0.2 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Appengine-User-IP: 192.168.1.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Appengine-User-IP: 8.8.8.8 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Appengine-User-IP: localhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Appengine-User-IP: norealhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Appengine-User-IP: null http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Arbitrary: * http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Arbitrary: 0.0.0.0 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Arbitrary: 0177.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Arbitrary: 10.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Arbitrary: 127.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Arbitrary: 172.17.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Arbitrary: 192.168.0.2 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Arbitrary: 192.168.1.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Arbitrary: 8.8.8.8 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Arbitrary: localhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Arbitrary: norealhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Arbitrary: null http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Backend-Host: * http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Backend-Host: 0.0.0.0 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Backend-Host: 0177.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Backend-Host: 10.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Backend-Host: 127.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Backend-Host: 172.17.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Backend-Host: 192.168.0.2 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Backend-Host: 192.168.1.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Backend-Host: 8.8.8.8 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Backend-Host: localhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Backend-Host: norealhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Backend-Host: null http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Backend-Server: * http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Backend-Server: 0.0.0.0 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Backend-Server: 0177.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Backend-Server: 10.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Backend-Server: 127.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Backend-Server: 172.17.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Backend-Server: 192.168.0.2 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Backend-Server: 192.168.1.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Backend-Server: 8.8.8.8 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Backend-Server: localhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Backend-Server: norealhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Backend-Server: null http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-BlueCoat-Via: * http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-BlueCoat-Via: 0.0.0.0 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-BlueCoat-Via: 0177.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-BlueCoat-Via: 10.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-BlueCoat-Via: 127.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-BlueCoat-Via: 172.17.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-BlueCoat-Via: 192.168.0.2 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-BlueCoat-Via: 192.168.1.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-BlueCoat-Via: 8.8.8.8 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-BlueCoat-Via: localhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-BlueCoat-Via: norealhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-BlueCoat-Via: null http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-C-IP: * http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-C-IP: 0.0.0.0 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-C-IP: 0177.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-C-IP: 10.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-C-IP: 127.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-C-IP: 172.17.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-C-IP: 192.168.0.2 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-C-IP: 192.168.1.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-C-IP: 8.8.8.8 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-C-IP: localhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-C-IP: norealhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-C-IP: null http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Cache-Info: * http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Cache-Info: 0.0.0.0 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Cache-Info: 0177.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Cache-Info: 10.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Cache-Info: 127.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Cache-Info: 172.17.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Cache-Info: 192.168.0.2 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Cache-Info: 192.168.1.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Cache-Info: 8.8.8.8 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Cache-Info: localhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Cache-Info: norealhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Cache-Info: null http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Client-Host: * http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Client-Host: 0.0.0.0 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Client-Host: 0177.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Client-Host: 10.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Client-Host: 127.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Client-Host: 172.17.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Client-Host: 192.168.0.2 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Client-Host: 192.168.1.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Client-Host: 8.8.8.8 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Client-Host: localhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Client-Host: norealhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Client-Host: null http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Client-IP: * http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Client-IP: 0.0.0.0 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Client-IP: 0177.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Client-IP: 10.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Client-IP: 127.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Client-IP: 172.17.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Client-IP: 192.168.0.2 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Client-IP: 192.168.1.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Client-IP: 8.8.8.8 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Client-IP: localhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Client-IP: norealhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Client-IP: null http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Cluster-Client-IP: * http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Cluster-Client-IP: 0.0.0.0 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Cluster-Client-IP: 0177.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Cluster-Client-IP: 10.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Cluster-Client-IP: 127.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Cluster-Client-IP: 172.17.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Cluster-Client-IP: 192.168.0.2 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Cluster-Client-IP: 192.168.1.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Cluster-Client-IP: 8.8.8.8 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Cluster-Client-IP: localhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Cluster-Client-IP: norealhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Cluster-Client-IP: null http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Cluster-IP: * http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Cluster-IP: 0.0.0.0 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Cluster-IP: 0177.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Cluster-IP: 10.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Cluster-IP: 127.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Cluster-IP: 172.17.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Cluster-IP: 192.168.0.2 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Cluster-IP: 192.168.1.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Cluster-IP: 8.8.8.8 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Cluster-IP: localhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Cluster-IP: norealhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Cluster-IP: null http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Custom-IP-Authorization: * http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Custom-IP-Authorization: 0.0.0.0 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Custom-IP-Authorization: 0177.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Custom-IP-Authorization: 10.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Custom-IP-Authorization: 127.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Custom-IP-Authorization: 172.17.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Custom-IP-Authorization: 192.168.0.2 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Custom-IP-Authorization: 192.168.1.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Custom-IP-Authorization: 8.8.8.8 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Custom-IP-Authorization: localhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Custom-IP-Authorization: norealhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Custom-IP-Authorization: null http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Dev-Host: * http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Dev-Host: 0.0.0.0 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Dev-Host: 0177.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Dev-Host: 10.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Dev-Host: 127.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Dev-Host: 172.17.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Dev-Host: 192.168.0.2 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Dev-Host: 192.168.1.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Dev-Host: 8.8.8.8 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Dev-Host: localhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Dev-Host: norealhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Dev-Host: null http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Ebay-Client-IP: * http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Ebay-Client-IP: 0.0.0.0 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Ebay-Client-IP: 0177.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Ebay-Client-IP: 10.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Ebay-Client-IP: 127.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Ebay-Client-IP: 172.17.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Ebay-Client-IP: 192.168.0.2 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Ebay-Client-IP: 192.168.1.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Ebay-Client-IP: 8.8.8.8 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Ebay-Client-IP: localhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Ebay-Client-IP: norealhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Ebay-Client-IP: null http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Fake-IP: * http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Fake-IP: 0.0.0.0 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Fake-IP: 0177.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Fake-IP: 10.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Fake-IP: 127.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Fake-IP: 172.17.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Fake-IP: 192.168.0.2 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Fake-IP: 192.168.1.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Fake-IP: 8.8.8.8 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Fake-IP: localhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Fake-IP: norealhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Fake-IP: null http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Fb-Host: * http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Fb-Host: 0.0.0.0 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Fb-Host: 0177.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Fb-Host: 10.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Fb-Host: 127.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Fb-Host: 172.17.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Fb-Host: 192.168.0.2 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Fb-Host: 192.168.1.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Fb-Host: 8.8.8.8 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Fb-Host: localhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Fb-Host: norealhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Fb-Host: null http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Fb-User-Remote-Addr: * http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Fb-User-Remote-Addr: 0.0.0.0 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Fb-User-Remote-Addr: 0177.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Fb-User-Remote-Addr: 10.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Fb-User-Remote-Addr: 127.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Fb-User-Remote-Addr: 172.17.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Fb-User-Remote-Addr: 192.168.0.2 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Fb-User-Remote-Addr: 192.168.1.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Fb-User-Remote-Addr: 8.8.8.8 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Fb-User-Remote-Addr: localhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Fb-User-Remote-Addr: norealhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Fb-User-Remote-Addr: null http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forward-For: * http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forward-For: 0.0.0.0 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forward-For: 0177.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forward-For: 10.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forward-For: 127.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forward-For: 172.17.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forward-For: 192.168.0.2 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forward-For: 192.168.1.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forward-For: 8.8.8.8 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forward-For: localhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forward-For: norealhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forward-For: null http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forward: * http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forward: 0.0.0.0 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forward: 0177.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forward: 10.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forward: 127.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forward: 172.17.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forward: 192.168.0.2 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forward: 192.168.1.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forward: 8.8.8.8 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forward: localhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forward: norealhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forward: null http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarded-By: * http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarded-By: 0.0.0.0 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarded-By: 0177.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarded-By: 10.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarded-By: 127.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarded-By: 172.17.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarded-By: 192.168.0.2 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarded-By: 192.168.1.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarded-By: 8.8.8.8 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarded-By: localhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarded-By: norealhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarded-By: null http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarded-For-IP: * http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarded-For-IP: 0.0.0.0 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarded-For-IP: 0177.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarded-For-IP: 10.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarded-For-IP: 127.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarded-For-IP: 172.17.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarded-For-IP: 192.168.0.2 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarded-For-IP: 192.168.1.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarded-For-IP: 8.8.8.8 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarded-For-IP: localhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarded-For-IP: norealhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarded-For-IP: null http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarded-For-Original: * http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarded-For-Original: 0.0.0.0 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarded-For-Original: 0177.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarded-For-Original: 10.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarded-For-Original: 127.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarded-For-Original: 172.17.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarded-For-Original: 192.168.0.2 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarded-For-Original: 192.168.1.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarded-For-Original: 8.8.8.8 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarded-For-Original: localhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarded-For-Original: norealhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarded-For-Original: null http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarded-For: * http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarded-For: 0.0.0.0 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarded-For: 0177.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarded-For: 10.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarded-For: 127.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarded-For: 172.17.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarded-For: 192.168.0.2 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarded-For: 192.168.1.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarded-For: 8.8.8.8 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarded-For: localhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarded-For: norealhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarded-For: null http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarded-From: * http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarded-From: 0.0.0.0 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarded-From: 0177.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarded-From: 10.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarded-From: 127.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarded-From: 172.17.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarded-From: 192.168.0.2 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarded-From: 192.168.1.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarded-From: 8.8.8.8 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarded-From: localhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarded-From: norealhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarded-From: null http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarded-Host: * http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarded-Host: 0.0.0.0 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarded-Host: 0177.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarded-Host: 10.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarded-Host: 127.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarded-Host: 172.17.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarded-Host: 192.168.0.2 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarded-Host: 192.168.1.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarded-Host: 8.8.8.8 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarded-Host: localhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarded-Host: norealhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarded-Host: null http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarded-Server: * http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarded-Server: 0.0.0.0 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarded-Server: 0177.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarded-Server: 10.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarded-Server: 127.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarded-Server: 172.17.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarded-Server: 192.168.0.2 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarded-Server: 192.168.1.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarded-Server: 8.8.8.8 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarded-Server: localhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarded-Server: norealhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarded-Server: null http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarded: * http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarded: 0.0.0.0 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarded: 0177.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarded: 10.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarded: 127.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarded: 172.17.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarded: 192.168.0.2 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarded: 192.168.1.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarded: 8.8.8.8 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarded: localhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarded: norealhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarded: null http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarder-For: * http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarder-For: 0.0.0.0 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarder-For: 0177.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarder-For: 10.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarder-For: 127.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarder-For: 172.17.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarder-For: 192.168.0.2 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarder-For: 192.168.1.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarder-For: 8.8.8.8 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarder-For: localhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarder-For: norealhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarder-For: null http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarder-Host: * http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarder-Host: 0.0.0.0 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarder-Host: 0177.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarder-Host: 10.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarder-Host: 127.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarder-Host: 172.17.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarder-Host: 192.168.0.2 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarder-Host: 192.168.1.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarder-Host: 8.8.8.8 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarder-Host: localhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarder-Host: norealhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarder-Host: null http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarder: * http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarder: 0.0.0.0 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarder: 0177.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarder: 10.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarder: 127.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarder: 172.17.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarder: 192.168.0.2 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarder: 192.168.1.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarder: 8.8.8.8 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarder: localhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarder: norealhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarder: null http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarding-For: * http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarding-For: 0.0.0.0 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarding-For: 0177.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarding-For: 10.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarding-For: 127.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarding-For: 172.17.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarding-For: 192.168.0.2 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarding-For: 192.168.1.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarding-For: 8.8.8.8 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarding-For: localhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarding-For: norealhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarding-For: null http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarding-Host: * http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarding-Host: 0.0.0.0 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarding-Host: 0177.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarding-Host: 10.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarding-Host: 127.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarding-Host: 172.17.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarding-Host: 192.168.0.2 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarding-Host: 192.168.1.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarding-Host: 8.8.8.8 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarding-Host: localhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarding-Host: norealhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarding-Host: null http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarding: * http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarding: 0.0.0.0 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarding: 0177.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarding: 10.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarding: 127.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarding: 172.17.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarding: 192.168.0.2 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarding: 192.168.1.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarding: 8.8.8.8 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarding: localhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarding: norealhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwarding: null http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwared-Host: * http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwared-Host: 0.0.0.0 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwared-Host: 0177.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwared-Host: 10.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwared-Host: 127.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwared-Host: 172.17.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwared-Host: 192.168.0.2 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwared-Host: 192.168.1.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwared-Host: 8.8.8.8 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwared-Host: localhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwared-Host: norealhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Forwared-Host: null http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-From-IP: * http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-From-IP: 0.0.0.0 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-From-IP: 0177.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-From-IP: 10.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-From-IP: 127.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-From-IP: 172.17.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-From-IP: 192.168.0.2 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-From-IP: 192.168.1.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-From-IP: 8.8.8.8 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-From-IP: localhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-From-IP: norealhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-From-IP: null http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-From: * http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-From: 0.0.0.0 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-From: 0177.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-From: 10.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-From: 127.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-From: 172.17.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-From: 192.168.0.2 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-From: 192.168.1.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-From: 8.8.8.8 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-From: localhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-From: norealhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-From: null http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Gateway-Host: * http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Gateway-Host: 0.0.0.0 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Gateway-Host: 0177.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Gateway-Host: 10.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Gateway-Host: 127.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Gateway-Host: 172.17.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Gateway-Host: 192.168.0.2 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Gateway-Host: 192.168.1.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Gateway-Host: 8.8.8.8 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Gateway-Host: localhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Gateway-Host: norealhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Gateway-Host: null http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-HTTP-Host-Override: * http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-HTTP-Host-Override: 0.0.0.0 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-HTTP-Host-Override: 0177.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-HTTP-Host-Override: 10.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-HTTP-Host-Override: 127.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-HTTP-Host-Override: 172.17.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-HTTP-Host-Override: 192.168.0.2 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-HTTP-Host-Override: 192.168.1.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-HTTP-Host-Override: 8.8.8.8 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-HTTP-Host-Override: localhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-HTTP-Host-Override: norealhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-HTTP-Host-Override: null http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Host-IP: * http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Host-IP: 0.0.0.0 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Host-IP: 0177.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Host-IP: 10.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Host-IP: 127.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Host-IP: 172.17.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Host-IP: 192.168.0.2 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Host-IP: 192.168.1.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Host-IP: 8.8.8.8 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Host-IP: localhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Host-IP: norealhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Host-IP: null http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Host-Override: * http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Host-Override: 0.0.0.0 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Host-Override: 0177.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Host-Override: 10.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Host-Override: 127.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Host-Override: 172.17.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Host-Override: 192.168.0.2 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Host-Override: 192.168.1.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Host-Override: 8.8.8.8 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Host-Override: localhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Host-Override: norealhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Host-Override: null http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Host: * http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Host: 0.0.0.0 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Host: 0177.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Host: 10.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Host: 127.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Host: 172.17.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Host: 192.168.0.2 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Host: 192.168.1.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Host: 8.8.8.8 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Host: localhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Host: norealhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Host: null http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Http-Host-Override: * http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Http-Host-Override: 0.0.0.0 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Http-Host-Override: 0177.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Http-Host-Override: 10.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Http-Host-Override: 127.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Http-Host-Override: 172.17.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Http-Host-Override: 192.168.0.2 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Http-Host-Override: 192.168.1.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Http-Host-Override: 8.8.8.8 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Http-Host-Override: localhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Http-Host-Override: norealhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Http-Host-Override: null http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Http-Method-Override: * http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Http-Method-Override: 0.0.0.0 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Http-Method-Override: 0177.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Http-Method-Override: 10.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Http-Method-Override: 127.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Http-Method-Override: 172.17.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Http-Method-Override: 192.168.0.2 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Http-Method-Override: 192.168.1.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Http-Method-Override: 8.8.8.8 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Http-Method-Override: localhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Http-Method-Override: norealhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Http-Method-Override: null http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-IP-Addr: * http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-IP-Addr: 0.0.0.0 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-IP-Addr: 0177.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-IP-Addr: 10.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-IP-Addr: 127.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-IP-Addr: 172.17.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-IP-Addr: 192.168.0.2 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-IP-Addr: 192.168.1.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-IP-Addr: 8.8.8.8 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-IP-Addr: localhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-IP-Addr: norealhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-IP-Addr: null http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-IP-Address: * http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-IP-Address: 0.0.0.0 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-IP-Address: 0177.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-IP-Address: 10.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-IP-Address: 127.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-IP-Address: 172.17.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-IP-Address: 192.168.0.2 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-IP-Address: 192.168.1.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-IP-Address: 8.8.8.8 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-IP-Address: localhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-IP-Address: norealhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-IP-Address: null http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-IP-Trail: * http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-IP-Trail: 0.0.0.0 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-IP-Trail: 0177.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-IP-Trail: 10.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-IP-Trail: 127.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-IP-Trail: 172.17.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-IP-Trail: 192.168.0.2 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-IP-Trail: 192.168.1.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-IP-Trail: 8.8.8.8 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-IP-Trail: localhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-IP-Trail: norealhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-IP-Trail: null http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-IP: * http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-IP: 0.0.0.0 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-IP: 0177.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-IP: 10.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-IP: 127.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-IP: 172.17.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-IP: 192.168.0.2 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-IP: 192.168.1.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-IP: 8.8.8.8 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-IP: localhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-IP: norealhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-IP: null http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-MS-ADFS-Proxy-Client-IP: * http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-MS-ADFS-Proxy-Client-IP: 0.0.0.0 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-MS-ADFS-Proxy-Client-IP: 0177.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-MS-ADFS-Proxy-Client-IP: 10.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-MS-ADFS-Proxy-Client-IP: 127.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-MS-ADFS-Proxy-Client-IP: 172.17.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-MS-ADFS-Proxy-Client-IP: 192.168.0.2 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-MS-ADFS-Proxy-Client-IP: 192.168.1.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-MS-ADFS-Proxy-Client-IP: 8.8.8.8 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-MS-ADFS-Proxy-Client-IP: localhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-MS-ADFS-Proxy-Client-IP: norealhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-MS-ADFS-Proxy-Client-IP: null http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-MS-Forwarded-Client-IP: * http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-MS-Forwarded-Client-IP: 0.0.0.0 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-MS-Forwarded-Client-IP: 0177.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-MS-Forwarded-Client-IP: 10.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-MS-Forwarded-Client-IP: 127.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-MS-Forwarded-Client-IP: 172.17.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-MS-Forwarded-Client-IP: 192.168.0.2 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-MS-Forwarded-Client-IP: 192.168.1.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-MS-Forwarded-Client-IP: 8.8.8.8 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-MS-Forwarded-Client-IP: localhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-MS-Forwarded-Client-IP: norealhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-MS-Forwarded-Client-IP: null http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Nokia-ipaddress: * http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Nokia-ipaddress: 0.0.0.0 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Nokia-ipaddress: 0177.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Nokia-ipaddress: 10.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Nokia-ipaddress: 127.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Nokia-ipaddress: 172.17.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Nokia-ipaddress: 192.168.0.2 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Nokia-ipaddress: 192.168.1.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Nokia-ipaddress: 8.8.8.8 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Nokia-ipaddress: localhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Nokia-ipaddress: norealhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Nokia-ipaddress: null http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Origin-Host: * http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Origin-Host: 0.0.0.0 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Origin-Host: 0177.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Origin-Host: 10.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Origin-Host: 127.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Origin-Host: 172.17.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Origin-Host: 192.168.0.2 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Origin-Host: 192.168.1.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Origin-Host: 8.8.8.8 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Origin-Host: localhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Origin-Host: norealhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Origin-Host: null http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Origin-IP: * http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Origin-IP: 0.0.0.0 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Origin-IP: 0177.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Origin-IP: 10.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Origin-IP: 127.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Origin-IP: 172.17.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Origin-IP: 192.168.0.2 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Origin-IP: 192.168.1.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Origin-IP: 8.8.8.8 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Origin-IP: localhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Origin-IP: norealhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Origin-IP: null http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Origin: * http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Origin: 0.0.0.0 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Origin: 0177.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Origin: 10.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Origin: 127.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Origin: 172.17.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Origin: 192.168.0.2 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Origin: 192.168.1.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Origin: 8.8.8.8 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Origin: localhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Origin: norealhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Origin: null http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Original-For: * http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Original-For: 0.0.0.0 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Original-For: 0177.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Original-For: 10.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Original-For: 127.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Original-For: 172.17.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Original-For: 192.168.0.2 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Original-For: 192.168.1.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Original-For: 8.8.8.8 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Original-For: localhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Original-For: norealhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Original-For: null http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Original-Forwarded-For: * http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Original-Forwarded-For: 0.0.0.0 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Original-Forwarded-For: 0177.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Original-Forwarded-For: 10.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Original-Forwarded-For: 127.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Original-Forwarded-For: 172.17.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Original-Forwarded-For: 192.168.0.2 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Original-Forwarded-For: 192.168.1.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Original-Forwarded-For: 8.8.8.8 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Original-Forwarded-For: localhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Original-Forwarded-For: norealhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Original-Forwarded-For: null http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Original-Host: * http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Original-Host: 0.0.0.0 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Original-Host: 0177.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Original-Host: 10.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Original-Host: 127.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Original-Host: 172.17.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Original-Host: 192.168.0.2 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Original-Host: 192.168.1.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Original-Host: 8.8.8.8 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Original-Host: localhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Original-Host: norealhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Original-Host: null http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Original-Hostname: * http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Original-Hostname: 0.0.0.0 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Original-Hostname: 0177.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Original-Hostname: 10.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Original-Hostname: 127.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Original-Hostname: 172.17.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Original-Hostname: 192.168.0.2 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Original-Hostname: 192.168.1.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Original-Hostname: 8.8.8.8 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Original-Hostname: localhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Original-Hostname: norealhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Original-Hostname: null http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Original-IP: * http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Original-IP: 0.0.0.0 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Original-IP: 0177.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Original-IP: 10.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Original-IP: 127.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Original-IP: 172.17.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Original-IP: 192.168.0.2 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Original-IP: 192.168.1.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Original-IP: 8.8.8.8 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Original-IP: localhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Original-IP: norealhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Original-IP: null http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Original-Remote-Addr: * http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Original-Remote-Addr: 0.0.0.0 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Original-Remote-Addr: 0177.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Original-Remote-Addr: 10.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Original-Remote-Addr: 127.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Original-Remote-Addr: 172.17.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Original-Remote-Addr: 192.168.0.2 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Original-Remote-Addr: 192.168.1.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Original-Remote-Addr: 8.8.8.8 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Original-Remote-Addr: localhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Original-Remote-Addr: norealhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Original-Remote-Addr: null http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Originally-Forwarded-For: * http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Originally-Forwarded-For: 0.0.0.0 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Originally-Forwarded-For: 0177.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Originally-Forwarded-For: 10.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Originally-Forwarded-For: 127.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Originally-Forwarded-For: 172.17.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Originally-Forwarded-For: 192.168.0.2 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Originally-Forwarded-For: 192.168.1.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Originally-Forwarded-For: 8.8.8.8 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Originally-Forwarded-For: localhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Originally-Forwarded-For: norealhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Originally-Forwarded-For: null http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Originating-Host: * http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Originating-Host: 0.0.0.0 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Originating-Host: 0177.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Originating-Host: 10.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Originating-Host: 127.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Originating-Host: 172.17.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Originating-Host: 192.168.0.2 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Originating-Host: 192.168.1.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Originating-Host: 8.8.8.8 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Originating-Host: localhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Originating-Host: norealhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Originating-Host: null http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Originating-IP: * http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Originating-IP: 0.0.0.0 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Originating-IP: 0177.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Originating-IP: 10.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Originating-IP: 127.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Originating-IP: 172.17.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Originating-IP: 192.168.0.2 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Originating-IP: 192.168.1.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Originating-IP: 8.8.8.8 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Originating-IP: localhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Originating-IP: norealhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Originating-IP: null http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Originating: * http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Originating: 0.0.0.0 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Originating: 0177.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Originating: 10.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Originating: 127.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Originating: 172.17.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Originating: 192.168.0.2 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Originating: 192.168.1.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Originating: 8.8.8.8 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Originating: localhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Originating: norealhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Originating: null http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Proxy-IP: * http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Proxy-IP: 0.0.0.0 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Proxy-IP: 0177.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Proxy-IP: 10.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Proxy-IP: 127.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Proxy-IP: 172.17.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Proxy-IP: 192.168.0.2 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Proxy-IP: 192.168.1.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Proxy-IP: 8.8.8.8 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Proxy-IP: localhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Proxy-IP: norealhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Proxy-IP: null http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Proxy: * http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Proxy: 0.0.0.0 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Proxy: 0177.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Proxy: 10.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Proxy: 127.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Proxy: 172.17.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Proxy: 192.168.0.2 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Proxy: 192.168.1.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Proxy: 8.8.8.8 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Proxy: localhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Proxy: norealhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Proxy: null http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-ProxyMesh-IP: * http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-ProxyMesh-IP: 0.0.0.0 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-ProxyMesh-IP: 0177.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-ProxyMesh-IP: 10.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-ProxyMesh-IP: 127.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-ProxyMesh-IP: 172.17.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-ProxyMesh-IP: 192.168.0.2 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-ProxyMesh-IP: 192.168.1.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-ProxyMesh-IP: 8.8.8.8 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-ProxyMesh-IP: localhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-ProxyMesh-IP: norealhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-ProxyMesh-IP: null http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-ProxyUser-IP: * http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-ProxyUser-IP: 0.0.0.0 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-ProxyUser-IP: 0177.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-ProxyUser-IP: 10.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-ProxyUser-IP: 127.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-ProxyUser-IP: 172.17.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-ProxyUser-IP: 192.168.0.2 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-ProxyUser-IP: 192.168.1.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-ProxyUser-IP: 8.8.8.8 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-ProxyUser-IP: localhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-ProxyUser-IP: norealhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-ProxyUser-IP: null http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Real-Client-IP: * http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Real-Client-IP: 0.0.0.0 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Real-Client-IP: 0177.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Real-Client-IP: 10.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Real-Client-IP: 127.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Real-Client-IP: 172.17.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Real-Client-IP: 192.168.0.2 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Real-Client-IP: 192.168.1.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Real-Client-IP: 8.8.8.8 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Real-Client-IP: localhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Real-Client-IP: norealhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Real-Client-IP: null http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Real-IP: * http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Real-IP: 0.0.0.0 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Real-IP: 0177.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Real-IP: 10.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Real-IP: 127.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Real-IP: 172.17.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Real-IP: 192.168.0.2 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Real-IP: 192.168.1.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Real-IP: 8.8.8.8 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Real-IP: localhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Real-IP: norealhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Real-IP: null http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Remote-Addr: * http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Remote-Addr: 0.0.0.0 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Remote-Addr: 0177.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Remote-Addr: 10.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Remote-Addr: 127.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Remote-Addr: 172.17.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Remote-Addr: 192.168.0.2 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Remote-Addr: 192.168.1.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Remote-Addr: 8.8.8.8 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Remote-Addr: localhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Remote-Addr: norealhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Remote-Addr: null http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Remote-Host: * http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Remote-Host: 0.0.0.0 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Remote-Host: 0177.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Remote-Host: 10.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Remote-Host: 127.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Remote-Host: 172.17.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Remote-Host: 192.168.0.2 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Remote-Host: 192.168.1.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Remote-Host: 8.8.8.8 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Remote-Host: localhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Remote-Host: norealhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Remote-Host: null http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Remote-IP: * http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Remote-IP: 0.0.0.0 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Remote-IP: 0177.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Remote-IP: 10.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Remote-IP: 127.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Remote-IP: 172.17.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Remote-IP: 192.168.0.2 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Remote-IP: 192.168.1.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Remote-IP: 8.8.8.8 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Remote-IP: localhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Remote-IP: norealhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Remote-IP: null http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Served-By: * http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Served-By: 0.0.0.0 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Served-By: 0177.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Served-By: 10.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Served-By: 127.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Served-By: 172.17.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Served-By: 192.168.0.2 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Served-By: 192.168.1.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Served-By: 8.8.8.8 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Served-By: localhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Served-By: norealhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Served-By: null http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Server-IP: * http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Server-IP: 0.0.0.0 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Server-IP: 0177.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Server-IP: 10.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Server-IP: 127.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Server-IP: 172.17.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Server-IP: 192.168.0.2 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Server-IP: 192.168.1.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Server-IP: 8.8.8.8 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Server-IP: localhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Server-IP: norealhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Server-IP: null http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Server-Name: * http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Server-Name: 0.0.0.0 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Server-Name: 0177.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Server-Name: 10.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Server-Name: 127.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Server-Name: 172.17.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Server-Name: 192.168.0.2 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Server-Name: 192.168.1.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Server-Name: 8.8.8.8 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Server-Name: localhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Server-Name: norealhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Server-Name: null http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Server: * http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Server: 0.0.0.0 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Server: 0177.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Server: 10.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Server: 127.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Server: 172.17.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Server: 192.168.0.2 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Server: 192.168.1.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Server: 8.8.8.8 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Server: localhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Server: norealhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Server: null http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Sp-Edge-Host: * http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Sp-Edge-Host: 0.0.0.0 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Sp-Edge-Host: 0177.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Sp-Edge-Host: 10.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Sp-Edge-Host: 127.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Sp-Edge-Host: 172.17.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Sp-Edge-Host: 192.168.0.2 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Sp-Edge-Host: 192.168.1.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Sp-Edge-Host: 8.8.8.8 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Sp-Edge-Host: localhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Sp-Edge-Host: norealhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Sp-Edge-Host: null http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Sp-Forwarded-IP: * http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Sp-Forwarded-IP: 0.0.0.0 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Sp-Forwarded-IP: 0177.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Sp-Forwarded-IP: 10.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Sp-Forwarded-IP: 127.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Sp-Forwarded-IP: 172.17.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Sp-Forwarded-IP: 192.168.0.2 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Sp-Forwarded-IP: 192.168.1.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Sp-Forwarded-IP: 8.8.8.8 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Sp-Forwarded-IP: localhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Sp-Forwarded-IP: norealhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Sp-Forwarded-IP: null http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-True-Client-IP: * http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-True-Client-IP: 0.0.0.0 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-True-Client-IP: 0177.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-True-Client-IP: 10.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-True-Client-IP: 127.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-True-Client-IP: 172.17.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-True-Client-IP: 192.168.0.2 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-True-Client-IP: 192.168.1.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-True-Client-IP: 8.8.8.8 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-True-Client-IP: localhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-True-Client-IP: norealhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-True-Client-IP: null http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-True-Client: * http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-True-Client: 0.0.0.0 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-True-Client: 0177.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-True-Client: 10.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-True-Client: 127.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-True-Client: 172.17.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-True-Client: 192.168.0.2 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-True-Client: 192.168.1.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-True-Client: 8.8.8.8 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-True-Client: localhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-True-Client: norealhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-True-Client: null http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-True-IP: * http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-True-IP: 0.0.0.0 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-True-IP: 0177.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-True-IP: 10.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-True-IP: 127.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-True-IP: 172.17.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-True-IP: 192.168.0.2 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-True-IP: 192.168.1.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-True-IP: 8.8.8.8 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-True-IP: localhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-True-IP: norealhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-True-IP: null http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-WAP-Network-Client-IP: * http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-WAP-Network-Client-IP: 0.0.0.0 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-WAP-Network-Client-IP: 0177.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-WAP-Network-Client-IP: 10.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-WAP-Network-Client-IP: 127.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-WAP-Network-Client-IP: 172.17.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-WAP-Network-Client-IP: 192.168.0.2 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-WAP-Network-Client-IP: 192.168.1.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-WAP-Network-Client-IP: 8.8.8.8 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-WAP-Network-Client-IP: localhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-WAP-Network-Client-IP: norealhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-WAP-Network-Client-IP: null http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Wap-Profile: * http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Wap-Profile: 0.0.0.0 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Wap-Profile: 0177.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Wap-Profile: 10.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Wap-Profile: 127.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Wap-Profile: 172.17.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Wap-Profile: 192.168.0.2 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Wap-Profile: 192.168.1.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Wap-Profile: 8.8.8.8 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Wap-Profile: localhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Wap-Profile: norealhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-Wap-Profile: null http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-YWBCLO-UIP: * http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-YWBCLO-UIP: 0.0.0.0 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-YWBCLO-UIP: 0177.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-YWBCLO-UIP: 10.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-YWBCLO-UIP: 127.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-YWBCLO-UIP: 172.17.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-YWBCLO-UIP: 192.168.0.2 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-YWBCLO-UIP: 192.168.1.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-YWBCLO-UIP: 8.8.8.8 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-YWBCLO-UIP: localhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-YWBCLO-UIP: norealhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H X-YWBCLO-UIP: null http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Z-Forwarded-For: * http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Z-Forwarded-For: 0.0.0.0 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Z-Forwarded-For: 0177.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Z-Forwarded-For: 10.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Z-Forwarded-For: 127.0.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Z-Forwarded-For: 172.17.0.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Z-Forwarded-For: 192.168.0.2 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Z-Forwarded-For: 192.168.1.1 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Z-Forwarded-For: 8.8.8.8 http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Z-Forwarded-For: localhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Z-Forwarded-For: norealhost http://127.0.0.1:8000/foo/bar
+[http_headers_ip] -H Z-Forwarded-For: null http://127.0.0.1:8000/foo/bar
+[http_headers_method] -H X-HTTP-Method-Override: ACL http://127.0.0.1:8000/foo/bar
+[http_headers_method] -H X-HTTP-Method-Override: BIND http://127.0.0.1:8000/foo/bar
+[http_headers_method] -H X-HTTP-Method-Override: CHECKIN http://127.0.0.1:8000/foo/bar
+[http_headers_method] -H X-HTTP-Method-Override: CHECKOUT http://127.0.0.1:8000/foo/bar
+[http_headers_method] -H X-HTTP-Method-Override: CONNECT http://127.0.0.1:8000/foo/bar
+[http_headers_method] -H X-HTTP-Method-Override: COPY http://127.0.0.1:8000/foo/bar
+[http_headers_method] -H X-HTTP-Method-Override: DELETE http://127.0.0.1:8000/foo/bar
+[http_headers_method] -H X-HTTP-Method-Override: GET http://127.0.0.1:8000/foo/bar
+[http_headers_method] -H X-HTTP-Method-Override: HEAD http://127.0.0.1:8000/foo/bar
+[http_headers_method] -H X-HTTP-Method-Override: LABEL http://127.0.0.1:8000/foo/bar
+[http_headers_method] -H X-HTTP-Method-Override: LINK http://127.0.0.1:8000/foo/bar
+[http_headers_method] -H X-HTTP-Method-Override: LOCK http://127.0.0.1:8000/foo/bar
+[http_headers_method] -H X-HTTP-Method-Override: MERGE http://127.0.0.1:8000/foo/bar
+[http_headers_method] -H X-HTTP-Method-Override: MKCOL http://127.0.0.1:8000/foo/bar
+[http_headers_method] -H X-HTTP-Method-Override: MOVE http://127.0.0.1:8000/foo/bar
+[http_headers_method] -H X-HTTP-Method-Override: OPTIONS http://127.0.0.1:8000/foo/bar
+[http_headers_method] -H X-HTTP-Method-Override: ORDERPATCH http://127.0.0.1:8000/foo/bar
+[http_headers_method] -H X-HTTP-Method-Override: PATCH http://127.0.0.1:8000/foo/bar
+[http_headers_method] -H X-HTTP-Method-Override: POST http://127.0.0.1:8000/foo/bar
+[http_headers_method] -H X-HTTP-Method-Override: POUET http://127.0.0.1:8000/foo/bar
+[http_headers_method] -H X-HTTP-Method-Override: PRI http://127.0.0.1:8000/foo/bar
+[http_headers_method] -H X-HTTP-Method-Override: PROPFIND http://127.0.0.1:8000/foo/bar
+[http_headers_method] -H X-HTTP-Method-Override: PROPPATCH http://127.0.0.1:8000/foo/bar
+[http_headers_method] -H X-HTTP-Method-Override: PUT http://127.0.0.1:8000/foo/bar
+[http_headers_method] -H X-HTTP-Method-Override: QUERY http://127.0.0.1:8000/foo/bar
+[http_headers_method] -H X-HTTP-Method-Override: REBIND http://127.0.0.1:8000/foo/bar
+[http_headers_method] -H X-HTTP-Method-Override: REPORT http://127.0.0.1:8000/foo/bar
+[http_headers_method] -H X-HTTP-Method-Override: SEARCH http://127.0.0.1:8000/foo/bar
+[http_headers_method] -H X-HTTP-Method-Override: TRACE http://127.0.0.1:8000/foo/bar
+[http_headers_method] -H X-HTTP-Method-Override: TRACK http://127.0.0.1:8000/foo/bar
+[http_headers_method] -H X-HTTP-Method-Override: UNCHECKOUT http://127.0.0.1:8000/foo/bar
+[http_headers_method] -H X-HTTP-Method-Override: UNLOCK http://127.0.0.1:8000/foo/bar
+[http_headers_method] -H X-HTTP-Method-Override: UPDATE http://127.0.0.1:8000/foo/bar
+[http_headers_method] -H X-HTTP-Method-Override: UPDATEREDIRECTREF http://127.0.0.1:8000/foo/bar
+[http_headers_method] -H X-HTTP-Method-Override: VERSION-CONTROL http://127.0.0.1:8000/foo/bar
+[http_headers_method] -H X-HTTP-Method: ACL http://127.0.0.1:8000/foo/bar
+[http_headers_method] -H X-HTTP-Method: BIND http://127.0.0.1:8000/foo/bar
+[http_headers_method] -H X-HTTP-Method: CHECKIN http://127.0.0.1:8000/foo/bar
+[http_headers_method] -H X-HTTP-Method: CHECKOUT http://127.0.0.1:8000/foo/bar
+[http_headers_method] -H X-HTTP-Method: CONNECT http://127.0.0.1:8000/foo/bar
+[http_headers_method] -H X-HTTP-Method: COPY http://127.0.0.1:8000/foo/bar
+[http_headers_method] -H X-HTTP-Method: DELETE http://127.0.0.1:8000/foo/bar
+[http_headers_method] -H X-HTTP-Method: GET http://127.0.0.1:8000/foo/bar
+[http_headers_method] -H X-HTTP-Method: HEAD http://127.0.0.1:8000/foo/bar
+[http_headers_method] -H X-HTTP-Method: LABEL http://127.0.0.1:8000/foo/bar
+[http_headers_method] -H X-HTTP-Method: LINK http://127.0.0.1:8000/foo/bar
+[http_headers_method] -H X-HTTP-Method: LOCK http://127.0.0.1:8000/foo/bar
+[http_headers_method] -H X-HTTP-Method: MERGE http://127.0.0.1:8000/foo/bar
+[http_headers_method] -H X-HTTP-Method: MKCOL http://127.0.0.1:8000/foo/bar
+[http_headers_method] -H X-HTTP-Method: MOVE http://127.0.0.1:8000/foo/bar
+[http_headers_method] -H X-HTTP-Method: OPTIONS http://127.0.0.1:8000/foo/bar
+[http_headers_method] -H X-HTTP-Method: ORDERPATCH http://127.0.0.1:8000/foo/bar
+[http_headers_method] -H X-HTTP-Method: PATCH http://127.0.0.1:8000/foo/bar
+[http_headers_method] -H X-HTTP-Method: POST http://127.0.0.1:8000/foo/bar
+[http_headers_method] -H X-HTTP-Method: POUET http://127.0.0.1:8000/foo/bar
+[http_headers_method] -H X-HTTP-Method: PRI http://127.0.0.1:8000/foo/bar
+[http_headers_method] -H X-HTTP-Method: PROPFIND http://127.0.0.1:8000/foo/bar
+[http_headers_method] -H X-HTTP-Method: PROPPATCH http://127.0.0.1:8000/foo/bar
+[http_headers_method] -H X-HTTP-Method: PUT http://127.0.0.1:8000/foo/bar
+[http_headers_method] -H X-HTTP-Method: QUERY http://127.0.0.1:8000/foo/bar
+[http_headers_method] -H X-HTTP-Method: REBIND http://127.0.0.1:8000/foo/bar
+[http_headers_method] -H X-HTTP-Method: REPORT http://127.0.0.1:8000/foo/bar
+[http_headers_method] -H X-HTTP-Method: SEARCH http://127.0.0.1:8000/foo/bar
+[http_headers_method] -H X-HTTP-Method: TRACE http://127.0.0.1:8000/foo/bar
+[http_headers_method] -H X-HTTP-Method: TRACK http://127.0.0.1:8000/foo/bar
+[http_headers_method] -H X-HTTP-Method: UNCHECKOUT http://127.0.0.1:8000/foo/bar
+[http_headers_method] -H X-HTTP-Method: UNLOCK http://127.0.0.1:8000/foo/bar
+[http_headers_method] -H X-HTTP-Method: UPDATE http://127.0.0.1:8000/foo/bar
+[http_headers_method] -H X-HTTP-Method: UPDATEREDIRECTREF http://127.0.0.1:8000/foo/bar
+[http_headers_method] -H X-HTTP-Method: VERSION-CONTROL http://127.0.0.1:8000/foo/bar
+[http_headers_port] -H Cdn-Server-Port: 1080 http://127.0.0.1:8000/foo/bar
+[http_headers_port] -H Cdn-Server-Port: 2080 http://127.0.0.1:8000/foo/bar
+[http_headers_port] -H Cdn-Server-Port: 3000 http://127.0.0.1:8000/foo/bar
+[http_headers_port] -H Cdn-Server-Port: 443 http://127.0.0.1:8000/foo/bar
+[http_headers_port] -H Cdn-Server-Port: 4443 http://127.0.0.1:8000/foo/bar
+[http_headers_port] -H Cdn-Server-Port: 74443 http://127.0.0.1:8000/foo/bar
+[http_headers_port] -H Cdn-Server-Port: 80 http://127.0.0.1:8000/foo/bar
+[http_headers_port] -H Cdn-Server-Port: 8000 http://127.0.0.1:8000/foo/bar
+[http_headers_port] -H Cdn-Server-Port: 8080 http://127.0.0.1:8000/foo/bar
+[http_headers_port] -H Cdn-Server-Port: 8443 http://127.0.0.1:8000/foo/bar
+[http_headers_port] -H Cdn-Server-Port: 9000 http://127.0.0.1:8000/foo/bar
+[http_headers_port] -H Cdn-Server-Port: 9080 http://127.0.0.1:8000/foo/bar
+[http_headers_port] -H Cdn-Server-Port: 9443 http://127.0.0.1:8000/foo/bar
+[http_headers_port] -H Cdn-Src-Port: 1080 http://127.0.0.1:8000/foo/bar
+[http_headers_port] -H Cdn-Src-Port: 2080 http://127.0.0.1:8000/foo/bar
+[http_headers_port] -H Cdn-Src-Port: 3000 http://127.0.0.1:8000/foo/bar
+[http_headers_port] -H Cdn-Src-Port: 443 http://127.0.0.1:8000/foo/bar
+[http_headers_port] -H Cdn-Src-Port: 4443 http://127.0.0.1:8000/foo/bar
+[http_headers_port] -H Cdn-Src-Port: 74443 http://127.0.0.1:8000/foo/bar
+[http_headers_port] -H Cdn-Src-Port: 80 http://127.0.0.1:8000/foo/bar
+[http_headers_port] -H Cdn-Src-Port: 8000 http://127.0.0.1:8000/foo/bar
+[http_headers_port] -H Cdn-Src-Port: 8080 http://127.0.0.1:8000/foo/bar
+[http_headers_port] -H Cdn-Src-Port: 8443 http://127.0.0.1:8000/foo/bar
+[http_headers_port] -H Cdn-Src-Port: 9000 http://127.0.0.1:8000/foo/bar
+[http_headers_port] -H Cdn-Src-Port: 9080 http://127.0.0.1:8000/foo/bar
+[http_headers_port] -H Cdn-Src-Port: 9443 http://127.0.0.1:8000/foo/bar
+[http_headers_port] -H Port: 1080 http://127.0.0.1:8000/foo/bar
+[http_headers_port] -H Port: 2080 http://127.0.0.1:8000/foo/bar
+[http_headers_port] -H Port: 3000 http://127.0.0.1:8000/foo/bar
+[http_headers_port] -H Port: 443 http://127.0.0.1:8000/foo/bar
+[http_headers_port] -H Port: 4443 http://127.0.0.1:8000/foo/bar
+[http_headers_port] -H Port: 74443 http://127.0.0.1:8000/foo/bar
+[http_headers_port] -H Port: 80 http://127.0.0.1:8000/foo/bar
+[http_headers_port] -H Port: 8000 http://127.0.0.1:8000/foo/bar
+[http_headers_port] -H Port: 8080 http://127.0.0.1:8000/foo/bar
+[http_headers_port] -H Port: 8443 http://127.0.0.1:8000/foo/bar
+[http_headers_port] -H Port: 9000 http://127.0.0.1:8000/foo/bar
+[http_headers_port] -H Port: 9080 http://127.0.0.1:8000/foo/bar
+[http_headers_port] -H Port: 9443 http://127.0.0.1:8000/foo/bar
+[http_headers_port] -H X-Cdn-Src-Port: 1080 http://127.0.0.1:8000/foo/bar
+[http_headers_port] -H X-Cdn-Src-Port: 2080 http://127.0.0.1:8000/foo/bar
+[http_headers_port] -H X-Cdn-Src-Port: 3000 http://127.0.0.1:8000/foo/bar
+[http_headers_port] -H X-Cdn-Src-Port: 443 http://127.0.0.1:8000/foo/bar
+[http_headers_port] -H X-Cdn-Src-Port: 4443 http://127.0.0.1:8000/foo/bar
+[http_headers_port] -H X-Cdn-Src-Port: 74443 http://127.0.0.1:8000/foo/bar
+[http_headers_port] -H X-Cdn-Src-Port: 80 http://127.0.0.1:8000/foo/bar
+[http_headers_port] -H X-Cdn-Src-Port: 8000 http://127.0.0.1:8000/foo/bar
+[http_headers_port] -H X-Cdn-Src-Port: 8080 http://127.0.0.1:8000/foo/bar
+[http_headers_port] -H X-Cdn-Src-Port: 8443 http://127.0.0.1:8000/foo/bar
+[http_headers_port] -H X-Cdn-Src-Port: 9000 http://127.0.0.1:8000/foo/bar
+[http_headers_port] -H X-Cdn-Src-Port: 9080 http://127.0.0.1:8000/foo/bar
+[http_headers_port] -H X-Cdn-Src-Port: 9443 http://127.0.0.1:8000/foo/bar
+[http_headers_port] -H X-Forwarded-Port: 1080 http://127.0.0.1:8000/foo/bar
+[http_headers_port] -H X-Forwarded-Port: 2080 http://127.0.0.1:8000/foo/bar
+[http_headers_port] -H X-Forwarded-Port: 3000 http://127.0.0.1:8000/foo/bar
+[http_headers_port] -H X-Forwarded-Port: 443 http://127.0.0.1:8000/foo/bar
+[http_headers_port] -H X-Forwarded-Port: 4443 http://127.0.0.1:8000/foo/bar
+[http_headers_port] -H X-Forwarded-Port: 74443 http://127.0.0.1:8000/foo/bar
+[http_headers_port] -H X-Forwarded-Port: 80 http://127.0.0.1:8000/foo/bar
+[http_headers_port] -H X-Forwarded-Port: 8000 http://127.0.0.1:8000/foo/bar
+[http_headers_port] -H X-Forwarded-Port: 8080 http://127.0.0.1:8000/foo/bar
+[http_headers_port] -H X-Forwarded-Port: 8443 http://127.0.0.1:8000/foo/bar
+[http_headers_port] -H X-Forwarded-Port: 9000 http://127.0.0.1:8000/foo/bar
+[http_headers_port] -H X-Forwarded-Port: 9080 http://127.0.0.1:8000/foo/bar
+[http_headers_port] -H X-Forwarded-Port: 9443 http://127.0.0.1:8000/foo/bar
+[http_headers_port] -H X-Port: 1080 http://127.0.0.1:8000/foo/bar
+[http_headers_port] -H X-Port: 2080 http://127.0.0.1:8000/foo/bar
+[http_headers_port] -H X-Port: 3000 http://127.0.0.1:8000/foo/bar
+[http_headers_port] -H X-Port: 443 http://127.0.0.1:8000/foo/bar
+[http_headers_port] -H X-Port: 4443 http://127.0.0.1:8000/foo/bar
+[http_headers_port] -H X-Port: 74443 http://127.0.0.1:8000/foo/bar
+[http_headers_port] -H X-Port: 80 http://127.0.0.1:8000/foo/bar
+[http_headers_port] -H X-Port: 8000 http://127.0.0.1:8000/foo/bar
+[http_headers_port] -H X-Port: 8080 http://127.0.0.1:8000/foo/bar
+[http_headers_port] -H X-Port: 8443 http://127.0.0.1:8000/foo/bar
+[http_headers_port] -H X-Port: 9000 http://127.0.0.1:8000/foo/bar
+[http_headers_port] -H X-Port: 9080 http://127.0.0.1:8000/foo/bar
+[http_headers_port] -H X-Port: 9443 http://127.0.0.1:8000/foo/bar
+[http_headers_port] -H X-Protocol-Port: 1080 http://127.0.0.1:8000/foo/bar
+[http_headers_port] -H X-Protocol-Port: 2080 http://127.0.0.1:8000/foo/bar
+[http_headers_port] -H X-Protocol-Port: 3000 http://127.0.0.1:8000/foo/bar
+[http_headers_port] -H X-Protocol-Port: 443 http://127.0.0.1:8000/foo/bar
+[http_headers_port] -H X-Protocol-Port: 4443 http://127.0.0.1:8000/foo/bar
+[http_headers_port] -H X-Protocol-Port: 74443 http://127.0.0.1:8000/foo/bar
+[http_headers_port] -H X-Protocol-Port: 80 http://127.0.0.1:8000/foo/bar
+[http_headers_port] -H X-Protocol-Port: 8000 http://127.0.0.1:8000/foo/bar
+[http_headers_port] -H X-Protocol-Port: 8080 http://127.0.0.1:8000/foo/bar
+[http_headers_port] -H X-Protocol-Port: 8443 http://127.0.0.1:8000/foo/bar
+[http_headers_port] -H X-Protocol-Port: 9000 http://127.0.0.1:8000/foo/bar
+[http_headers_port] -H X-Protocol-Port: 9080 http://127.0.0.1:8000/foo/bar
+[http_headers_port] -H X-Protocol-Port: 9443 http://127.0.0.1:8000/foo/bar
+[http_headers_scheme] -H CloudFront-Forwarded-Proto: foo http://127.0.0.1:8000/foo/bar
+[http_headers_scheme] -H CloudFront-Forwarded-Proto: ftp http://127.0.0.1:8000/foo/bar
+[http_headers_scheme] -H CloudFront-Forwarded-Proto: http http://127.0.0.1:8000/foo/bar
+[http_headers_scheme] -H CloudFront-Forwarded-Proto: https http://127.0.0.1:8000/foo/bar
+[http_headers_scheme] -H CloudFront-Forwarded-Proto: webdav http://127.0.0.1:8000/foo/bar
+[http_headers_scheme] -H Forwarded: proto=foo http://127.0.0.1:8000/foo/bar
+[http_headers_scheme] -H Forwarded: proto=ftp http://127.0.0.1:8000/foo/bar
+[http_headers_scheme] -H Forwarded: proto=http http://127.0.0.1:8000/foo/bar
+[http_headers_scheme] -H Forwarded: proto=https http://127.0.0.1:8000/foo/bar
+[http_headers_scheme] -H Forwarded: proto=webdav http://127.0.0.1:8000/foo/bar
+[http_headers_scheme] -H Front-End-Https: on http://127.0.0.1:8000/foo/bar
+[http_headers_scheme] -H X-Forwarded-HTTPS: on http://127.0.0.1:8000/foo/bar
+[http_headers_scheme] -H X-Forwarded-Proto: foo http://127.0.0.1:8000/foo/bar
+[http_headers_scheme] -H X-Forwarded-Proto: ftp http://127.0.0.1:8000/foo/bar
+[http_headers_scheme] -H X-Forwarded-Proto: http http://127.0.0.1:8000/foo/bar
+[http_headers_scheme] -H X-Forwarded-Proto: https http://127.0.0.1:8000/foo/bar
+[http_headers_scheme] -H X-Forwarded-Proto: webdav http://127.0.0.1:8000/foo/bar
+[http_headers_scheme] -H X-Forwarded-SSL: on http://127.0.0.1:8000/foo/bar
+[http_headers_scheme] -H X-Forwarded-Scheme: foo http://127.0.0.1:8000/foo/bar
+[http_headers_scheme] -H X-Forwarded-Scheme: ftp http://127.0.0.1:8000/foo/bar
+[http_headers_scheme] -H X-Forwarded-Scheme: http http://127.0.0.1:8000/foo/bar
+[http_headers_scheme] -H X-Forwarded-Scheme: https http://127.0.0.1:8000/foo/bar
+[http_headers_scheme] -H X-Forwarded-Scheme: webdav http://127.0.0.1:8000/foo/bar
+[http_headers_scheme] -H X-Protocol-Scheme: foo http://127.0.0.1:8000/foo/bar
+[http_headers_scheme] -H X-Protocol-Scheme: ftp http://127.0.0.1:8000/foo/bar
+[http_headers_scheme] -H X-Protocol-Scheme: http http://127.0.0.1:8000/foo/bar
+[http_headers_scheme] -H X-Protocol-Scheme: https http://127.0.0.1:8000/foo/bar
+[http_headers_scheme] -H X-Protocol-Scheme: webdav http://127.0.0.1:8000/foo/bar
+[http_headers_scheme] -H X-Sp-Edge-Scheme: foo http://127.0.0.1:8000/foo/bar
+[http_headers_scheme] -H X-Sp-Edge-Scheme: ftp http://127.0.0.1:8000/foo/bar
+[http_headers_scheme] -H X-Sp-Edge-Scheme: http http://127.0.0.1:8000/foo/bar
+[http_headers_scheme] -H X-Sp-Edge-Scheme: https http://127.0.0.1:8000/foo/bar
+[http_headers_scheme] -H X-Sp-Edge-Scheme: webdav http://127.0.0.1:8000/foo/bar
+[http_headers_scheme] -H X-Url-Scheme: foo http://127.0.0.1:8000/foo/bar
+[http_headers_scheme] -H X-Url-Scheme: ftp http://127.0.0.1:8000/foo/bar
+[http_headers_scheme] -H X-Url-Scheme: http http://127.0.0.1:8000/foo/bar
+[http_headers_scheme] -H X-Url-Scheme: https http://127.0.0.1:8000/foo/bar
+[http_headers_scheme] -H X-Url-Scheme: webdav http://127.0.0.1:8000/foo/bar
+[http_methods] -X ACL http://127.0.0.1:8000/foo/bar
+[http_methods] -X BIND http://127.0.0.1:8000/foo/bar
+[http_methods] -X CHECKIN http://127.0.0.1:8000/foo/bar
+[http_methods] -X CHECKOUT http://127.0.0.1:8000/foo/bar
+[http_methods] -X CONNECT http://127.0.0.1:8000/foo/bar
+[http_methods] -X COPY http://127.0.0.1:8000/foo/bar
+[http_methods] -X DELETE http://127.0.0.1:8000/foo/bar
+[http_methods] -X GET http://127.0.0.1:8000/foo/bar
+[http_methods] -X HEAD http://127.0.0.1:8000/foo/bar
+[http_methods] -X LABEL http://127.0.0.1:8000/foo/bar
+[http_methods] -X LINK http://127.0.0.1:8000/foo/bar
+[http_methods] -X LOCK http://127.0.0.1:8000/foo/bar
+[http_methods] -X MERGE http://127.0.0.1:8000/foo/bar
+[http_methods] -X MKCOL http://127.0.0.1:8000/foo/bar
+[http_methods] -X MOVE http://127.0.0.1:8000/foo/bar
+[http_methods] -X OPTIONS http://127.0.0.1:8000/foo/bar
+[http_methods] -X ORDERPATCH http://127.0.0.1:8000/foo/bar
+[http_methods] -X PATCH http://127.0.0.1:8000/foo/bar
+[http_methods] -X POST http://127.0.0.1:8000/foo/bar
+[http_methods] -X POUET http://127.0.0.1:8000/foo/bar
+[http_methods] -X PRI http://127.0.0.1:8000/foo/bar
+[http_methods] -X PROPFIND http://127.0.0.1:8000/foo/bar
+[http_methods] -X PROPPATCH http://127.0.0.1:8000/foo/bar
+[http_methods] -X PUT http://127.0.0.1:8000/foo/bar
+[http_methods] -X QUERY http://127.0.0.1:8000/foo/bar
+[http_methods] -X REBIND http://127.0.0.1:8000/foo/bar
+[http_methods] -X REPORT http://127.0.0.1:8000/foo/bar
+[http_methods] -X SEARCH http://127.0.0.1:8000/foo/bar
+[http_methods] -X TRACE http://127.0.0.1:8000/foo/bar
+[http_methods] -X TRACK http://127.0.0.1:8000/foo/bar
+[http_methods] -X UNCHECKOUT http://127.0.0.1:8000/foo/bar
+[http_methods] -X UNLOCK http://127.0.0.1:8000/foo/bar
+[http_methods] -X UPDATE http://127.0.0.1:8000/foo/bar
+[http_methods] -X UPDATEREDIRECTREF http://127.0.0.1:8000/foo/bar
+[http_methods] -X VERSION-CONTROL http://127.0.0.1:8000/foo/bar
+[http_versions] --http0.9 http://127.0.0.1:8000/foo/bar
+[http_versions] --http1.0 http://127.0.0.1:8000/foo/bar
+[http_versions] --http1.1 http://127.0.0.1:8000/foo/bar
+[http_versions] --http2 http://127.0.0.1:8000/foo/bar
+[http_versions] --http2-prior-knowledge http://127.0.0.1:8000/foo/bar
+[mid_paths] http://127.0.0.1:8000/#?foo/bar
+[mid_paths] http://127.0.0.1:8000/#foo/bar
+[mid_paths] http://127.0.0.1:8000/%09%3bfoo/bar
+[mid_paths] http://127.0.0.1:8000/%09..foo/bar
+[mid_paths] http://127.0.0.1:8000/%09;foo/bar
+[mid_paths] http://127.0.0.1:8000/%09foo/bar
+[mid_paths] http://127.0.0.1:8000/%20/foo/bar
+[mid_paths] http://127.0.0.1:8000/%20foo/bar
+[mid_paths] http://127.0.0.1:8000/%23%3ffoo/bar
+[mid_paths] http://127.0.0.1:8000/%23foo/bar
+[mid_paths] http://127.0.0.1:8000/%252f%252ffoo/bar
+[mid_paths] http://127.0.0.1:8000/%252f/foo/bar
+[mid_paths] http://127.0.0.1:8000/%26foo/bar
+[mid_paths] http://127.0.0.1:8000/%2e%2e%2ffoo/bar
+[mid_paths] http://127.0.0.1:8000/%2e%2e/foo/bar
+[mid_paths] http://127.0.0.1:8000/%2e%2efoo/bar
+[mid_paths] http://127.0.0.1:8000/%2e/foo/bar
+[mid_paths] http://127.0.0.1:8000/%2efoo/bar
+[mid_paths] http://127.0.0.1:8000/%2f%20%23foo/bar
+[mid_paths] http://127.0.0.1:8000/%2f%23foo/bar
+[mid_paths] http://127.0.0.1:8000/%2f%2ffoo/bar
+[mid_paths] http://127.0.0.1:8000/%2f%3b%2f%2ffoo/bar
+[mid_paths] http://127.0.0.1:8000/%2f%3b%2ffoo/bar
+[mid_paths] http://127.0.0.1:8000/%2f%3f/foo/bar
+[mid_paths] http://127.0.0.1:8000/%2f%3ffoo/bar
+[mid_paths] http://127.0.0.1:8000/%2f/foo/bar
+[mid_paths] http://127.0.0.1:8000/%2ffoo/bar
+[mid_paths] http://127.0.0.1:8000/%3b%09foo/bar
+[mid_paths] http://127.0.0.1:8000/%3b%2f%2e%2e%2f%2e%2e%2f%2ffoo/bar
+[mid_paths] http://127.0.0.1:8000/%3b%2f%2e%2efoo/bar
+[mid_paths] http://127.0.0.1:8000/%3b%2f%2e.foo/bar
+[mid_paths] http://127.0.0.1:8000/%3b%2f..foo/bar
+[mid_paths] http://127.0.0.1:8000/%3b/%2e%2e/..%2f%2ffoo/bar
+[mid_paths] http://127.0.0.1:8000/%3b/%2e.foo/bar
+[mid_paths] http://127.0.0.1:8000/%3b/%2f%2f../foo/bar
+[mid_paths] http://127.0.0.1:8000/%3b/..foo/bar
+[mid_paths] http://127.0.0.1:8000/%3b//%2f../foo/bar
+[mid_paths] http://127.0.0.1:8000/%3bfoo/bar
+[mid_paths] http://127.0.0.1:8000/%3f%23foo/bar
+[mid_paths] http://127.0.0.1:8000/%3f%3ffoo/bar
+[mid_paths] http://127.0.0.1:8000/%3ffoo/bar
+[mid_paths] http://127.0.0.1:8000/%foo/bar
+[mid_paths] http://127.0.0.1:8000/&foo/bar
+[mid_paths] http://127.0.0.1:8000/.%2e/foo/bar
+[mid_paths] http://127.0.0.1:8000/..%00/;foo/bar
+[mid_paths] http://127.0.0.1:8000/..%00/foo/bar
+[mid_paths] http://127.0.0.1:8000/..%00;/foo/bar
+[mid_paths] http://127.0.0.1:8000/..%09foo/bar
+[mid_paths] http://127.0.0.1:8000/..%0d/;foo/bar
+[mid_paths] http://127.0.0.1:8000/..%0d/foo/bar
+[mid_paths] http://127.0.0.1:8000/..%0d;/foo/bar
+[mid_paths] http://127.0.0.1:8000/..%2ffoo/bar
+[mid_paths] http://127.0.0.1:8000/..%3Bfoo/bar
+[mid_paths] http://127.0.0.1:8000/..%5c/foo/bar
+[mid_paths] http://127.0.0.1:8000/..%5cfoo/bar
+[mid_paths] http://127.0.0.1:8000/..%ff/;foo/bar
+[mid_paths] http://127.0.0.1:8000/..%ff;/foo/bar
+[mid_paths] http://127.0.0.1:8000/..%fffoo/bar
+[mid_paths] http://127.0.0.1:8000/.././foo/bar
+[mid_paths] http://127.0.0.1:8000/../foo/bar
+[mid_paths] http://127.0.0.1:8000/..;%00/foo/bar
+[mid_paths] http://127.0.0.1:8000/..;%0d/foo/bar
+[mid_paths] http://127.0.0.1:8000/..;%ff/foo/bar
+[mid_paths] http://127.0.0.1:8000/..;/foo/bar
+[mid_paths] http://127.0.0.1:8000/..;\;foo/bar
+[mid_paths] http://127.0.0.1:8000/..;\\foo/bar
+[mid_paths] http://127.0.0.1:8000/..;foo/bar
+[mid_paths] http://127.0.0.1:8000/..\;foo/bar
+[mid_paths] http://127.0.0.1:8000/..\\foo/bar
+[mid_paths] http://127.0.0.1:8000/..foo/bar
+[mid_paths] http://127.0.0.1:8000/./.foo/bar
+[mid_paths] http://127.0.0.1:8000/.//./foo/bar
+[mid_paths] http://127.0.0.1:8000/./foo/bar
+[mid_paths] http://127.0.0.1:8000/.;/foo/bar
+[mid_paths] http://127.0.0.1:8000/.htmlfoo/bar
+[mid_paths] http://127.0.0.1:8000/.jsonfoo/bar
+[mid_paths] http://127.0.0.1:8000//#?foo/bar
+[mid_paths] http://127.0.0.1:8000//#foo/bar
+[mid_paths] http://127.0.0.1:8000//%09%3bfoo/bar
+[mid_paths] http://127.0.0.1:8000//%09..foo/bar
+[mid_paths] http://127.0.0.1:8000//%09;foo/bar
+[mid_paths] http://127.0.0.1:8000//%09foo/bar
+[mid_paths] http://127.0.0.1:8000//%20#foo/bar
+[mid_paths] http://127.0.0.1:8000//%20%20/foo/bar
+[mid_paths] http://127.0.0.1:8000//%20%23foo/bar
+[mid_paths] http://127.0.0.1:8000//%20/foo/bar
+[mid_paths] http://127.0.0.1:8000//%20foo/bar
+[mid_paths] http://127.0.0.1:8000//%23%3ffoo/bar
+[mid_paths] http://127.0.0.1:8000//%23foo/bar
+[mid_paths] http://127.0.0.1:8000//%252e%252e%252f/foo/bar
+[mid_paths] http://127.0.0.1:8000//%252e%252e%253b/foo/bar
+[mid_paths] http://127.0.0.1:8000//%252e%252f/foo/bar
+[mid_paths] http://127.0.0.1:8000//%252e%253b/foo/bar
+[mid_paths] http://127.0.0.1:8000//%252e/foo/bar
+[mid_paths] http://127.0.0.1:8000//%252f%252ffoo/bar
+[mid_paths] http://127.0.0.1:8000//%252f/foo/bar
+[mid_paths] http://127.0.0.1:8000//%252ffoo/bar
+[mid_paths] http://127.0.0.1:8000//%26foo/bar
+[mid_paths] http://127.0.0.1:8000//%2e%2e%2ffoo/bar
+[mid_paths] http://127.0.0.1:8000//%2e%2e%3b/foo/bar
+[mid_paths] http://127.0.0.1:8000//%2e%2e/foo/bar
+[mid_paths] http://127.0.0.1:8000//%2e%2efoo/bar
+[mid_paths] http://127.0.0.1:8000//%2e%2f/foo/bar
+[mid_paths] http://127.0.0.1:8000//%2e%3b//foo/bar
+[mid_paths] http://127.0.0.1:8000//%2e%3b/foo/bar
+[mid_paths] http://127.0.0.1:8000//%2e//foo/bar
+[mid_paths] http://127.0.0.1:8000//%2e/foo/bar
+[mid_paths] http://127.0.0.1:8000//%2efoo/bar
+[mid_paths] http://127.0.0.1:8000//%2f%20%23foo/bar
+[mid_paths] http://127.0.0.1:8000//%2f%23foo/bar
+[mid_paths] http://127.0.0.1:8000//%2f%2ffoo/bar
+[mid_paths] http://127.0.0.1:8000//%2f%3b%2f%2ffoo/bar
+[mid_paths] http://127.0.0.1:8000//%2f%3b%2ffoo/bar
+[mid_paths] http://127.0.0.1:8000//%2f%3f/foo/bar
+[mid_paths] http://127.0.0.1:8000//%2f%3ffoo/bar
+[mid_paths] http://127.0.0.1:8000//%2f/foo/bar
+[mid_paths] http://127.0.0.1:8000//%2ffoo/bar
+[mid_paths] http://127.0.0.1:8000//%3b%09foo/bar
+[mid_paths] http://127.0.0.1:8000//%3b%2f%2e%2e%2f%2e%2e%2f%2ffoo/bar
+[mid_paths] http://127.0.0.1:8000//%3b%2f%2e%2efoo/bar
+[mid_paths] http://127.0.0.1:8000//%3b%2f%2e.foo/bar
+[mid_paths] http://127.0.0.1:8000//%3b%2f..foo/bar
+[mid_paths] http://127.0.0.1:8000//%3b/%2e%2e/..%2f%2ffoo/bar
+[mid_paths] http://127.0.0.1:8000//%3b/%2e.foo/bar
+[mid_paths] http://127.0.0.1:8000//%3b/%2f%2f../foo/bar
+[mid_paths] http://127.0.0.1:8000//%3b/..foo/bar
+[mid_paths] http://127.0.0.1:8000//%3b//%2f../foo/bar
+[mid_paths] http://127.0.0.1:8000//%3b/foo/bar
+[mid_paths] http://127.0.0.1:8000//%3bfoo/bar
+[mid_paths] http://127.0.0.1:8000//%3f%23foo/bar
+[mid_paths] http://127.0.0.1:8000//%3f%3ffoo/bar
+[mid_paths] http://127.0.0.1:8000//%3ffoo/bar
+[mid_paths] http://127.0.0.1:8000//%foo/bar
+[mid_paths] http://127.0.0.1:8000//&foo/bar
+[mid_paths] http://127.0.0.1:8000//*/foo/bar
+[mid_paths] http://127.0.0.1:8000//*foo/bar
+[mid_paths] http://127.0.0.1:8000//.%2e/foo/bar
+[mid_paths] http://127.0.0.1:8000//..%00/;foo/bar
+[mid_paths] http://127.0.0.1:8000//..%00/foo/bar
+[mid_paths] http://127.0.0.1:8000//..%00;/foo/bar
+[mid_paths] http://127.0.0.1:8000//..%09foo/bar
+[mid_paths] http://127.0.0.1:8000//..%0d/;foo/bar
+[mid_paths] http://127.0.0.1:8000//..%0d/foo/bar
+[mid_paths] http://127.0.0.1:8000//..%0d;/foo/bar
+[mid_paths] http://127.0.0.1:8000//..%2f..%2f..%2ffoo/bar
+[mid_paths] http://127.0.0.1:8000//..%2f..%2ffoo/bar
+[mid_paths] http://127.0.0.1:8000//..%2ffoo/bar
+[mid_paths] http://127.0.0.1:8000//..%3Bfoo/bar
+[mid_paths] http://127.0.0.1:8000//..%5c/foo/bar
+[mid_paths] http://127.0.0.1:8000//..%5cfoo/bar
+[mid_paths] http://127.0.0.1:8000//..%ff/;foo/bar
+[mid_paths] http://127.0.0.1:8000//..%ff;/foo/bar
+[mid_paths] http://127.0.0.1:8000//..%fffoo/bar
+[mid_paths] http://127.0.0.1:8000//../../..//foo/bar
+[mid_paths] http://127.0.0.1:8000//../../../foo/bar
+[mid_paths] http://127.0.0.1:8000//../..//../foo/bar
+[mid_paths] http://127.0.0.1:8000//../..//foo/bar
+[mid_paths] http://127.0.0.1:8000//../../foo/bar
+[mid_paths] http://127.0.0.1:8000//../..;/foo/bar
+[mid_paths] http://127.0.0.1:8000//.././../foo/bar
+[mid_paths] http://127.0.0.1:8000//.././foo/bar
+[mid_paths] http://127.0.0.1:8000//../.;/../foo/bar
+[mid_paths] http://127.0.0.1:8000//..//../../foo/bar
+[mid_paths] http://127.0.0.1:8000//..//../foo/bar
+[mid_paths] http://127.0.0.1:8000//..//..;/foo/bar
+[mid_paths] http://127.0.0.1:8000//..//foo/bar
+[mid_paths] http://127.0.0.1:8000//../;/../foo/bar
+[mid_paths] http://127.0.0.1:8000//../;/foo/bar
+[mid_paths] http://127.0.0.1:8000//../foo/bar
+[mid_paths] http://127.0.0.1:8000//..;%00/foo/bar
+[mid_paths] http://127.0.0.1:8000//..;%0d/foo/bar
+[mid_paths] http://127.0.0.1:8000//..;%2f..;%2f..;%2ffoo/bar
+[mid_paths] http://127.0.0.1:8000//..;%2f..;%2ffoo/bar
+[mid_paths] http://127.0.0.1:8000//..;%2ffoo/bar
+[mid_paths] http://127.0.0.1:8000//..;%ff/foo/bar
+[mid_paths] http://127.0.0.1:8000//..;/../foo/bar
+[mid_paths] http://127.0.0.1:8000//..;/..;/foo/bar
+[mid_paths] http://127.0.0.1:8000//..;//../foo/bar
+[mid_paths] http://127.0.0.1:8000//..;//..;/foo/bar
+[mid_paths] http://127.0.0.1:8000//..;//foo/bar
+[mid_paths] http://127.0.0.1:8000//..;/;/..;/foo/bar
+[mid_paths] http://127.0.0.1:8000//..;/;/foo/bar
+[mid_paths] http://127.0.0.1:8000//..;/foo/bar
+[mid_paths] http://127.0.0.1:8000//..;\;foo/bar
+[mid_paths] http://127.0.0.1:8000//..;\\foo/bar
+[mid_paths] http://127.0.0.1:8000//..;foo/bar
+[mid_paths] http://127.0.0.1:8000//..\;foo/bar
+[mid_paths] http://127.0.0.1:8000//..\\foo/bar
+[mid_paths] http://127.0.0.1:8000//..foo/bar
+[mid_paths] http://127.0.0.1:8000//./.foo/bar
+[mid_paths] http://127.0.0.1:8000//.//./foo/bar
+[mid_paths] http://127.0.0.1:8000//.//foo/bar
+[mid_paths] http://127.0.0.1:8000//./foo/bar
+[mid_paths] http://127.0.0.1:8000//.;//foo/bar
+[mid_paths] http://127.0.0.1:8000//.;/foo/bar
+[mid_paths] http://127.0.0.1:8000//.foo/bar
+[mid_paths] http://127.0.0.1:8000//.htmlfoo/bar
+[mid_paths] http://127.0.0.1:8000//.jsonfoo/bar
+[mid_paths] http://127.0.0.1:8000//.randomstringfoo/bar
+[mid_paths] http://127.0.0.1:8000///%20#foo/bar
+[mid_paths] http://127.0.0.1:8000///%20%20/foo/bar
+[mid_paths] http://127.0.0.1:8000///%20%23foo/bar
+[mid_paths] http://127.0.0.1:8000///%252e%252e%252f/foo/bar
+[mid_paths] http://127.0.0.1:8000///%252e%252e%253b/foo/bar
+[mid_paths] http://127.0.0.1:8000///%252e%252f/foo/bar
+[mid_paths] http://127.0.0.1:8000///%252e%253b/foo/bar
+[mid_paths] http://127.0.0.1:8000///%252e/foo/bar
+[mid_paths] http://127.0.0.1:8000///%252ffoo/bar
+[mid_paths] http://127.0.0.1:8000///%2e%2e%3b/foo/bar
+[mid_paths] http://127.0.0.1:8000///%2e%2e/foo/bar
+[mid_paths] http://127.0.0.1:8000///%2e%2efoo/bar
+[mid_paths] http://127.0.0.1:8000///%2e%2f/foo/bar
+[mid_paths] http://127.0.0.1:8000///%2e%3b//foo/bar
+[mid_paths] http://127.0.0.1:8000///%2e%3b/foo/bar
+[mid_paths] http://127.0.0.1:8000///%2e//foo/bar
+[mid_paths] http://127.0.0.1:8000///%2e/foo/bar
+[mid_paths] http://127.0.0.1:8000///%2ffoo/bar
+[mid_paths] http://127.0.0.1:8000///%3b/foo/bar
+[mid_paths] http://127.0.0.1:8000///*/foo/bar
+[mid_paths] http://127.0.0.1:8000///*foo/bar
+[mid_paths] http://127.0.0.1:8000///..%2f..%2f..%2ffoo/bar
+[mid_paths] http://127.0.0.1:8000///..%2f..%2ffoo/bar
+[mid_paths] http://127.0.0.1:8000///..%2ffoo/bar
+[mid_paths] http://127.0.0.1:8000///../../..//foo/bar
+[mid_paths] http://127.0.0.1:8000///../../../foo/bar
+[mid_paths] http://127.0.0.1:8000///../..//../foo/bar
+[mid_paths] http://127.0.0.1:8000///../..//foo/bar
+[mid_paths] http://127.0.0.1:8000///../../foo/bar
+[mid_paths] http://127.0.0.1:8000///../..;/foo/bar
+[mid_paths] http://127.0.0.1:8000///.././../foo/bar
+[mid_paths] http://127.0.0.1:8000///../.;/../foo/bar
+[mid_paths] http://127.0.0.1:8000///..//../../foo/bar
+[mid_paths] http://127.0.0.1:8000///..//../foo/bar
+[mid_paths] http://127.0.0.1:8000///..//..;/foo/bar
+[mid_paths] http://127.0.0.1:8000///..//foo/bar
+[mid_paths] http://127.0.0.1:8000///../;/../foo/bar
+[mid_paths] http://127.0.0.1:8000///../;/foo/bar
+[mid_paths] http://127.0.0.1:8000///../foo/bar
+[mid_paths] http://127.0.0.1:8000///..;%2f..;%2f..;%2ffoo/bar
+[mid_paths] http://127.0.0.1:8000///..;%2f..;%2ffoo/bar
+[mid_paths] http://127.0.0.1:8000///..;%2ffoo/bar
+[mid_paths] http://127.0.0.1:8000///..;/../foo/bar
+[mid_paths] http://127.0.0.1:8000///..;/..;/foo/bar
+[mid_paths] http://127.0.0.1:8000///..;//../foo/bar
+[mid_paths] http://127.0.0.1:8000///..;//..;/foo/bar
+[mid_paths] http://127.0.0.1:8000///..;//foo/bar
+[mid_paths] http://127.0.0.1:8000///..;/;/..;/foo/bar
+[mid_paths] http://127.0.0.1:8000///..;/;/foo/bar
+[mid_paths] http://127.0.0.1:8000///..;/foo/bar
+[mid_paths] http://127.0.0.1:8000///..;foo/bar
+[mid_paths] http://127.0.0.1:8000///..foo/bar
+[mid_paths] http://127.0.0.1:8000///.//foo/bar
+[mid_paths] http://127.0.0.1:8000///./foo/bar
+[mid_paths] http://127.0.0.1:8000///.;//foo/bar
+[mid_paths] http://127.0.0.1:8000///.;/foo/bar
+[mid_paths] http://127.0.0.1:8000///.foo/bar
+[mid_paths] http://127.0.0.1:8000///.randomstringfoo/bar
+[mid_paths] http://127.0.0.1:8000////../../foo/bar
+[mid_paths] http://127.0.0.1:8000////..//foo/bar
+[mid_paths] http://127.0.0.1:8000////../foo/bar
+[mid_paths] http://127.0.0.1:8000////..;//foo/bar
+[mid_paths] http://127.0.0.1:8000////..;/foo/bar
+[mid_paths] http://127.0.0.1:8000////..;foo/bar
+[mid_paths] http://127.0.0.1:8000////..foo/bar
+[mid_paths] http://127.0.0.1:8000////./foo/bar
+[mid_paths] http://127.0.0.1:8000////.;/foo/bar
+[mid_paths] http://127.0.0.1:8000////.foo/bar
+[mid_paths] http://127.0.0.1:8000/////..//foo/bar
+[mid_paths] http://127.0.0.1:8000/////../foo/bar
+[mid_paths] http://127.0.0.1:8000/////..;//foo/bar
+[mid_paths] http://127.0.0.1:8000/////..;/foo/bar
+[mid_paths] http://127.0.0.1:8000/////..;foo/bar
+[mid_paths] http://127.0.0.1:8000/////..foo/bar
+[mid_paths] http://127.0.0.1:8000//////foo/bar
+[mid_paths] http://127.0.0.1:8000/////foo/bar
+[mid_paths] http://127.0.0.1:8000////;/foo/bar
+[mid_paths] http://127.0.0.1:8000////?anythingfoo/bar
+[mid_paths] http://127.0.0.1:8000////foo/bar
+[mid_paths] http://127.0.0.1:8000///;//foo/bar
+[mid_paths] http://127.0.0.1:8000///;/foo/bar
+[mid_paths] http://127.0.0.1:8000///;x/foo/bar
+[mid_paths] http://127.0.0.1:8000///;xfoo/bar
+[mid_paths] http://127.0.0.1:8000///?anythingfoo/bar
+[mid_paths] http://127.0.0.1:8000///foo/bar
+[mid_paths] http://127.0.0.1:8000///x/..//foo/bar
+[mid_paths] http://127.0.0.1:8000///x/../;/foo/bar
+[mid_paths] http://127.0.0.1:8000///x/../foo/bar
+[mid_paths] http://127.0.0.1:8000///x/..;//foo/bar
+[mid_paths] http://127.0.0.1:8000///x/..;/;/foo/bar
+[mid_paths] http://127.0.0.1:8000///x/..;/foo/bar
+[mid_paths] http://127.0.0.1:8000///x//../foo/bar
+[mid_paths] http://127.0.0.1:8000///x//..;/foo/bar
+[mid_paths] http://127.0.0.1:8000///x/;/../foo/bar
+[mid_paths] http://127.0.0.1:8000///x/;/..;/foo/bar
+[mid_paths] http://127.0.0.1:8000//;%09..;foo/bar
+[mid_paths] http://127.0.0.1:8000//;%09..foo/bar
+[mid_paths] http://127.0.0.1:8000//;%09;foo/bar
+[mid_paths] http://127.0.0.1:8000//;%09foo/bar
+[mid_paths] http://127.0.0.1:8000//;%2f%2e%2e%2f%2e%2e%2f%2ffoo/bar
+[mid_paths] http://127.0.0.1:8000//;%2f%2e%2efoo/bar
+[mid_paths] http://127.0.0.1:8000//;%2f%2f/../foo/bar
+[mid_paths] http://127.0.0.1:8000//;%2f..%2f%2e%2e%2f%2ffoo/bar
+[mid_paths] http://127.0.0.1:8000//;%2f..%2f..%2f%2ffoo/bar
+[mid_paths] http://127.0.0.1:8000//;%2f..%2f/..%2ffoo/bar
+[mid_paths] http://127.0.0.1:8000//;%2f..%2f/../foo/bar
+[mid_paths] http://127.0.0.1:8000//;%2f..%2f/foo/bar
+[mid_paths] http://127.0.0.1:8000//;%2f../%2f..%2ffoo/bar
+[mid_paths] http://127.0.0.1:8000//;%2f../%2f../foo/bar
+[mid_paths] http://127.0.0.1:8000//;%2f..//..%2ffoo/bar
+[mid_paths] http://127.0.0.1:8000//;%2f..//../foo/bar
+[mid_paths] http://127.0.0.1:8000//;%2f..///;foo/bar
+[mid_paths] http://127.0.0.1:8000//;%2f..///foo/bar
+[mid_paths] http://127.0.0.1:8000//;%2f..//;/;foo/bar
+[mid_paths] http://127.0.0.1:8000//;%2f..//;/foo/bar
+[mid_paths] http://127.0.0.1:8000//;%2f../;//foo/bar
+[mid_paths] http://127.0.0.1:8000//;%2f../;/;/;foo/bar
+[mid_paths] http://127.0.0.1:8000//;%2f../;/;/foo/bar
+[mid_paths] http://127.0.0.1:8000//;%2f..;///foo/bar
+[mid_paths] http://127.0.0.1:8000//;%2f..;//;/foo/bar
+[mid_paths] http://127.0.0.1:8000//;%2f..;/;//foo/bar
+[mid_paths] http://127.0.0.1:8000//;%2f..foo/bar
+[mid_paths] http://127.0.0.1:8000//;%2f/%2f../foo/bar
+[mid_paths] http://127.0.0.1:8000//;%2f//..%2ffoo/bar
+[mid_paths] http://127.0.0.1:8000//;%2f//../foo/bar
+[mid_paths] http://127.0.0.1:8000//;%2f//..;/foo/bar
+[mid_paths] http://127.0.0.1:8000//;%2f/;/../foo/bar
+[mid_paths] http://127.0.0.1:8000//;%2f/;/..;/foo/bar
+[mid_paths] http://127.0.0.1:8000//;%2f;//../foo/bar
+[mid_paths] http://127.0.0.1:8000//;%2f;/;/..;/foo/bar
+[mid_paths] http://127.0.0.1:8000//;/%2e%2e%2f%2ffoo/bar
+[mid_paths] http://127.0.0.1:8000//;/%2e%2e%2f/foo/bar
+[mid_paths] http://127.0.0.1:8000//;/%2e%2e/foo/bar
+[mid_paths] http://127.0.0.1:8000//;/%2e%2efoo/bar
+[mid_paths] http://127.0.0.1:8000//;/%2e.foo/bar
+[mid_paths] http://127.0.0.1:8000//;/%2f%2f../foo/bar
+[mid_paths] http://127.0.0.1:8000//;/%2f/..%2ffoo/bar
+[mid_paths] http://127.0.0.1:8000//;/%2f/../foo/bar
+[mid_paths] http://127.0.0.1:8000//;/.%2e/%2e%2e/%2ffoo/bar
+[mid_paths] http://127.0.0.1:8000//;/.%2efoo/bar
+[mid_paths] http://127.0.0.1:8000//;/..%2f%2f../foo/bar
+[mid_paths] http://127.0.0.1:8000//;/..%2f..%2ffoo/bar
+[mid_paths] http://127.0.0.1:8000//;/..%2f//foo/bar
+[mid_paths] http://127.0.0.1:8000//;/..%2f/foo/bar
+[mid_paths] http://127.0.0.1:8000//;/..%2ffoo/bar
+[mid_paths] http://127.0.0.1:8000//;/../%2f/foo/bar
+[mid_paths] http://127.0.0.1:8000//;/../..//foo/bar
+[mid_paths] http://127.0.0.1:8000//;/../../foo/bar
+[mid_paths] http://127.0.0.1:8000//;/.././../foo/bar
+[mid_paths] http://127.0.0.1:8000//;/../.;/../foo/bar
+[mid_paths] http://127.0.0.1:8000//;/..//%2e%2e/foo/bar
+[mid_paths] http://127.0.0.1:8000//;/..//%2ffoo/bar
+[mid_paths] http://127.0.0.1:8000//;/..//../foo/bar
+[mid_paths] http://127.0.0.1:8000//;/..///foo/bar
+[mid_paths] http://127.0.0.1:8000//;/..//foo/bar
+[mid_paths] http://127.0.0.1:8000//;/../;/../foo/bar
+[mid_paths] http://127.0.0.1:8000//;/../;/foo/bar
+[mid_paths] http://127.0.0.1:8000//;/../foo/bar
+[mid_paths] http://127.0.0.1:8000//;/..;foo/bar
+[mid_paths] http://127.0.0.1:8000//;/..foo/bar
+[mid_paths] http://127.0.0.1:8000//;/.;.foo/bar
+[mid_paths] http://127.0.0.1:8000//;//%2f../foo/bar
+[mid_paths] http://127.0.0.1:8000//;//../../foo/bar
+[mid_paths] http://127.0.0.1:8000//;//..foo/bar
+[mid_paths] http://127.0.0.1:8000//;///..//foo/bar
+[mid_paths] http://127.0.0.1:8000//;///../foo/bar
+[mid_paths] http://127.0.0.1:8000//;///..foo/bar
+[mid_paths] http://127.0.0.1:8000//;//foo/bar
+[mid_paths] http://127.0.0.1:8000//;/foo/bar
+[mid_paths] http://127.0.0.1:8000//;foo/bar
+[mid_paths] http://127.0.0.1:8000//;x/foo/bar
+[mid_paths] http://127.0.0.1:8000//;x;foo/bar
+[mid_paths] http://127.0.0.1:8000//;xfoo/bar
+[mid_paths] http://127.0.0.1:8000//???foo/bar
+[mid_paths] http://127.0.0.1:8000//??foo/bar
+[mid_paths] http://127.0.0.1:8000//?foo/bar
+[mid_paths] http://127.0.0.1:8000//\..\.\foo/bar
+[mid_paths] http://127.0.0.1:8000//foo/#?bar
+[mid_paths] http://127.0.0.1:8000//foo/#bar
+[mid_paths] http://127.0.0.1:8000//foo/%09%3bbar
+[mid_paths] http://127.0.0.1:8000//foo/%09..bar
+[mid_paths] http://127.0.0.1:8000//foo/%09;bar
+[mid_paths] http://127.0.0.1:8000//foo/%09bar
+[mid_paths] http://127.0.0.1:8000//foo/%20/bar
+[mid_paths] http://127.0.0.1:8000//foo/%20bar
+[mid_paths] http://127.0.0.1:8000//foo/%23%3fbar
+[mid_paths] http://127.0.0.1:8000//foo/%23bar
+[mid_paths] http://127.0.0.1:8000//foo/%252f%252fbar
+[mid_paths] http://127.0.0.1:8000//foo/%252f/bar
+[mid_paths] http://127.0.0.1:8000//foo/%26bar
+[mid_paths] http://127.0.0.1:8000//foo/%2e%2e%2fbar
+[mid_paths] http://127.0.0.1:8000//foo/%2e%2e/bar
+[mid_paths] http://127.0.0.1:8000//foo/%2e%2ebar
+[mid_paths] http://127.0.0.1:8000//foo/%2e/bar
+[mid_paths] http://127.0.0.1:8000//foo/%2ebar
+[mid_paths] http://127.0.0.1:8000//foo/%2f%20%23bar
+[mid_paths] http://127.0.0.1:8000//foo/%2f%23bar
+[mid_paths] http://127.0.0.1:8000//foo/%2f%2fbar
+[mid_paths] http://127.0.0.1:8000//foo/%2f%3b%2f%2fbar
+[mid_paths] http://127.0.0.1:8000//foo/%2f%3b%2fbar
+[mid_paths] http://127.0.0.1:8000//foo/%2f%3f/bar
+[mid_paths] http://127.0.0.1:8000//foo/%2f%3fbar
+[mid_paths] http://127.0.0.1:8000//foo/%2f/bar
+[mid_paths] http://127.0.0.1:8000//foo/%2fbar
+[mid_paths] http://127.0.0.1:8000//foo/%3b%09bar
+[mid_paths] http://127.0.0.1:8000//foo/%3b%2f%2e%2e%2f%2e%2e%2f%2fbar
+[mid_paths] http://127.0.0.1:8000//foo/%3b%2f%2e%2ebar
+[mid_paths] http://127.0.0.1:8000//foo/%3b%2f%2e.bar
+[mid_paths] http://127.0.0.1:8000//foo/%3b%2f..bar
+[mid_paths] http://127.0.0.1:8000//foo/%3b/%2e%2e/..%2f%2fbar
+[mid_paths] http://127.0.0.1:8000//foo/%3b/%2e.bar
+[mid_paths] http://127.0.0.1:8000//foo/%3b/%2f%2f../bar
+[mid_paths] http://127.0.0.1:8000//foo/%3b/..bar
+[mid_paths] http://127.0.0.1:8000//foo/%3b//%2f../bar
+[mid_paths] http://127.0.0.1:8000//foo/%3bbar
+[mid_paths] http://127.0.0.1:8000//foo/%3f%23bar
+[mid_paths] http://127.0.0.1:8000//foo/%3f%3fbar
+[mid_paths] http://127.0.0.1:8000//foo/%3fbar
+[mid_paths] http://127.0.0.1:8000//foo/%bar
+[mid_paths] http://127.0.0.1:8000//foo/&bar
+[mid_paths] http://127.0.0.1:8000//foo/.%2e/bar
+[mid_paths] http://127.0.0.1:8000//foo/..%00/;bar
+[mid_paths] http://127.0.0.1:8000//foo/..%00/bar
+[mid_paths] http://127.0.0.1:8000//foo/..%00;/bar
+[mid_paths] http://127.0.0.1:8000//foo/..%09bar
+[mid_paths] http://127.0.0.1:8000//foo/..%0d/;bar
+[mid_paths] http://127.0.0.1:8000//foo/..%0d/bar
+[mid_paths] http://127.0.0.1:8000//foo/..%0d;/bar
+[mid_paths] http://127.0.0.1:8000//foo/..%2fbar
+[mid_paths] http://127.0.0.1:8000//foo/..%3Bbar
+[mid_paths] http://127.0.0.1:8000//foo/..%5c/bar
+[mid_paths] http://127.0.0.1:8000//foo/..%5cbar
+[mid_paths] http://127.0.0.1:8000//foo/..%ff/;bar
+[mid_paths] http://127.0.0.1:8000//foo/..%ff;/bar
+[mid_paths] http://127.0.0.1:8000//foo/..%ffbar
+[mid_paths] http://127.0.0.1:8000//foo/.././bar
+[mid_paths] http://127.0.0.1:8000//foo/../bar
+[mid_paths] http://127.0.0.1:8000//foo/..;%00/bar
+[mid_paths] http://127.0.0.1:8000//foo/..;%0d/bar
+[mid_paths] http://127.0.0.1:8000//foo/..;%ff/bar
+[mid_paths] http://127.0.0.1:8000//foo/..;/bar
+[mid_paths] http://127.0.0.1:8000//foo/..;\;bar
+[mid_paths] http://127.0.0.1:8000//foo/..;\\bar
+[mid_paths] http://127.0.0.1:8000//foo/..;bar
+[mid_paths] http://127.0.0.1:8000//foo/..\;bar
+[mid_paths] http://127.0.0.1:8000//foo/..\\bar
+[mid_paths] http://127.0.0.1:8000//foo/..bar
+[mid_paths] http://127.0.0.1:8000//foo/./.bar
+[mid_paths] http://127.0.0.1:8000//foo/.//./bar
+[mid_paths] http://127.0.0.1:8000//foo/./bar
+[mid_paths] http://127.0.0.1:8000//foo/.;/bar
+[mid_paths] http://127.0.0.1:8000//foo/.htmlbar
+[mid_paths] http://127.0.0.1:8000//foo/.jsonbar
+[mid_paths] http://127.0.0.1:8000//foo//%20#bar
+[mid_paths] http://127.0.0.1:8000//foo//%20%20/bar
+[mid_paths] http://127.0.0.1:8000//foo//%20%23bar
+[mid_paths] http://127.0.0.1:8000//foo//%252e%252e%252f/bar
+[mid_paths] http://127.0.0.1:8000//foo//%252e%252e%253b/bar
+[mid_paths] http://127.0.0.1:8000//foo//%252e%252f/bar
+[mid_paths] http://127.0.0.1:8000//foo//%252e%253b/bar
+[mid_paths] http://127.0.0.1:8000//foo//%252e/bar
+[mid_paths] http://127.0.0.1:8000//foo//%252fbar
+[mid_paths] http://127.0.0.1:8000//foo//%2e%2e%3b/bar
+[mid_paths] http://127.0.0.1:8000//foo//%2e%2e/bar
+[mid_paths] http://127.0.0.1:8000//foo//%2e%2ebar
+[mid_paths] http://127.0.0.1:8000//foo//%2e%2f/bar
+[mid_paths] http://127.0.0.1:8000//foo//%2e%3b//bar
+[mid_paths] http://127.0.0.1:8000//foo//%2e%3b/bar
+[mid_paths] http://127.0.0.1:8000//foo//%2e//bar
+[mid_paths] http://127.0.0.1:8000//foo//%2e/bar
+[mid_paths] http://127.0.0.1:8000//foo//%2fbar
+[mid_paths] http://127.0.0.1:8000//foo//%3b/bar
+[mid_paths] http://127.0.0.1:8000//foo//*/bar
+[mid_paths] http://127.0.0.1:8000//foo//*bar
+[mid_paths] http://127.0.0.1:8000//foo//..%2f..%2f..%2fbar
+[mid_paths] http://127.0.0.1:8000//foo//..%2f..%2fbar
+[mid_paths] http://127.0.0.1:8000//foo//..%2fbar
+[mid_paths] http://127.0.0.1:8000//foo//../../..//bar
+[mid_paths] http://127.0.0.1:8000//foo//../../../bar
+[mid_paths] http://127.0.0.1:8000//foo//../..//../bar
+[mid_paths] http://127.0.0.1:8000//foo//../..//bar
+[mid_paths] http://127.0.0.1:8000//foo//../../bar
+[mid_paths] http://127.0.0.1:8000//foo//../..;/bar
+[mid_paths] http://127.0.0.1:8000//foo//.././../bar
+[mid_paths] http://127.0.0.1:8000//foo//../.;/../bar
+[mid_paths] http://127.0.0.1:8000//foo//..//../../bar
+[mid_paths] http://127.0.0.1:8000//foo//..//../bar
+[mid_paths] http://127.0.0.1:8000//foo//..//..;/bar
+[mid_paths] http://127.0.0.1:8000//foo//..//bar
+[mid_paths] http://127.0.0.1:8000//foo//../;/../bar
+[mid_paths] http://127.0.0.1:8000//foo//../;/bar
+[mid_paths] http://127.0.0.1:8000//foo//../bar
+[mid_paths] http://127.0.0.1:8000//foo//..;%2f..;%2f..;%2fbar
+[mid_paths] http://127.0.0.1:8000//foo//..;%2f..;%2fbar
+[mid_paths] http://127.0.0.1:8000//foo//..;%2fbar
+[mid_paths] http://127.0.0.1:8000//foo//..;/../bar
+[mid_paths] http://127.0.0.1:8000//foo//..;/..;/bar
+[mid_paths] http://127.0.0.1:8000//foo//..;//../bar
+[mid_paths] http://127.0.0.1:8000//foo//..;//..;/bar
+[mid_paths] http://127.0.0.1:8000//foo//..;//bar
+[mid_paths] http://127.0.0.1:8000//foo//..;/;/..;/bar
+[mid_paths] http://127.0.0.1:8000//foo//..;/;/bar
+[mid_paths] http://127.0.0.1:8000//foo//..;/bar
+[mid_paths] http://127.0.0.1:8000//foo//..bar
+[mid_paths] http://127.0.0.1:8000//foo//.//bar
+[mid_paths] http://127.0.0.1:8000//foo//./bar
+[mid_paths] http://127.0.0.1:8000//foo//.;//bar
+[mid_paths] http://127.0.0.1:8000//foo//.;/bar
+[mid_paths] http://127.0.0.1:8000//foo//.bar
+[mid_paths] http://127.0.0.1:8000//foo//.randomstringbar
+[mid_paths] http://127.0.0.1:8000//foo///../../bar
+[mid_paths] http://127.0.0.1:8000//foo///..;bar
+[mid_paths] http://127.0.0.1:8000//foo///..bar
+[mid_paths] http://127.0.0.1:8000//foo///./bar
+[mid_paths] http://127.0.0.1:8000//foo///.;/bar
+[mid_paths] http://127.0.0.1:8000//foo///.bar
+[mid_paths] http://127.0.0.1:8000//foo////..//bar
+[mid_paths] http://127.0.0.1:8000//foo////../bar
+[mid_paths] http://127.0.0.1:8000//foo////..;//bar
+[mid_paths] http://127.0.0.1:8000//foo////..;/bar
+[mid_paths] http://127.0.0.1:8000//foo////..;bar
+[mid_paths] http://127.0.0.1:8000//foo////..bar
+[mid_paths] http://127.0.0.1:8000//foo/////bar
+[mid_paths] http://127.0.0.1:8000//foo///;/bar
+[mid_paths] http://127.0.0.1:8000//foo///?anythingbar
+[mid_paths] http://127.0.0.1:8000//foo///bar
+[mid_paths] http://127.0.0.1:8000//foo//;//bar
+[mid_paths] http://127.0.0.1:8000//foo//;/bar
+[mid_paths] http://127.0.0.1:8000//foo//;x/bar
+[mid_paths] http://127.0.0.1:8000//foo//;xbar
+[mid_paths] http://127.0.0.1:8000//foo//bar
+[mid_paths] http://127.0.0.1:8000//foo//x/..//bar
+[mid_paths] http://127.0.0.1:8000//foo//x/../;/bar
+[mid_paths] http://127.0.0.1:8000//foo//x/../bar
+[mid_paths] http://127.0.0.1:8000//foo//x/..;//bar
+[mid_paths] http://127.0.0.1:8000//foo//x/..;/;/bar
+[mid_paths] http://127.0.0.1:8000//foo//x/..;/bar
+[mid_paths] http://127.0.0.1:8000//foo//x//../bar
+[mid_paths] http://127.0.0.1:8000//foo//x//..;/bar
+[mid_paths] http://127.0.0.1:8000//foo//x/;/../bar
+[mid_paths] http://127.0.0.1:8000//foo//x/;/..;/bar
+[mid_paths] http://127.0.0.1:8000//foo/;%09..;bar
+[mid_paths] http://127.0.0.1:8000//foo/;%09..bar
+[mid_paths] http://127.0.0.1:8000//foo/;%09;bar
+[mid_paths] http://127.0.0.1:8000//foo/;%09bar
+[mid_paths] http://127.0.0.1:8000//foo/;%2f%2e%2e%2f%2e%2e%2f%2fbar
+[mid_paths] http://127.0.0.1:8000//foo/;%2f%2e%2ebar
+[mid_paths] http://127.0.0.1:8000//foo/;%2f%2f/../bar
+[mid_paths] http://127.0.0.1:8000//foo/;%2f..%2f%2e%2e%2f%2fbar
+[mid_paths] http://127.0.0.1:8000//foo/;%2f..%2f..%2f%2fbar
+[mid_paths] http://127.0.0.1:8000//foo/;%2f..%2f/..%2fbar
+[mid_paths] http://127.0.0.1:8000//foo/;%2f..%2f/../bar
+[mid_paths] http://127.0.0.1:8000//foo/;%2f..%2f/bar
+[mid_paths] http://127.0.0.1:8000//foo/;%2f../%2f..%2fbar
+[mid_paths] http://127.0.0.1:8000//foo/;%2f../%2f../bar
+[mid_paths] http://127.0.0.1:8000//foo/;%2f..//..%2fbar
+[mid_paths] http://127.0.0.1:8000//foo/;%2f..//../bar
+[mid_paths] http://127.0.0.1:8000//foo/;%2f..///;bar
+[mid_paths] http://127.0.0.1:8000//foo/;%2f..///bar
+[mid_paths] http://127.0.0.1:8000//foo/;%2f..//;/;bar
+[mid_paths] http://127.0.0.1:8000//foo/;%2f..//;/bar
+[mid_paths] http://127.0.0.1:8000//foo/;%2f../;//bar
+[mid_paths] http://127.0.0.1:8000//foo/;%2f../;/;/;bar
+[mid_paths] http://127.0.0.1:8000//foo/;%2f../;/;/bar
+[mid_paths] http://127.0.0.1:8000//foo/;%2f..;///bar
+[mid_paths] http://127.0.0.1:8000//foo/;%2f..;//;/bar
+[mid_paths] http://127.0.0.1:8000//foo/;%2f..;/;//bar
+[mid_paths] http://127.0.0.1:8000//foo/;%2f..bar
+[mid_paths] http://127.0.0.1:8000//foo/;%2f/%2f../bar
+[mid_paths] http://127.0.0.1:8000//foo/;%2f//..%2fbar
+[mid_paths] http://127.0.0.1:8000//foo/;%2f//../bar
+[mid_paths] http://127.0.0.1:8000//foo/;%2f//..;/bar
+[mid_paths] http://127.0.0.1:8000//foo/;%2f/;/../bar
+[mid_paths] http://127.0.0.1:8000//foo/;%2f/;/..;/bar
+[mid_paths] http://127.0.0.1:8000//foo/;%2f;//../bar
+[mid_paths] http://127.0.0.1:8000//foo/;%2f;/;/..;/bar
+[mid_paths] http://127.0.0.1:8000//foo/;/%2e%2e%2f%2fbar
+[mid_paths] http://127.0.0.1:8000//foo/;/%2e%2e%2f/bar
+[mid_paths] http://127.0.0.1:8000//foo/;/%2e%2e/bar
+[mid_paths] http://127.0.0.1:8000//foo/;/%2e%2ebar
+[mid_paths] http://127.0.0.1:8000//foo/;/%2e.bar
+[mid_paths] http://127.0.0.1:8000//foo/;/%2f%2f../bar
+[mid_paths] http://127.0.0.1:8000//foo/;/%2f/..%2fbar
+[mid_paths] http://127.0.0.1:8000//foo/;/%2f/../bar
+[mid_paths] http://127.0.0.1:8000//foo/;/.%2e/%2e%2e/%2fbar
+[mid_paths] http://127.0.0.1:8000//foo/;/.%2ebar
+[mid_paths] http://127.0.0.1:8000//foo/;/..%2f%2f../bar
+[mid_paths] http://127.0.0.1:8000//foo/;/..%2f..%2fbar
+[mid_paths] http://127.0.0.1:8000//foo/;/..%2f//bar
+[mid_paths] http://127.0.0.1:8000//foo/;/..%2f/bar
+[mid_paths] http://127.0.0.1:8000//foo/;/..%2fbar
+[mid_paths] http://127.0.0.1:8000//foo/;/../%2f/bar
+[mid_paths] http://127.0.0.1:8000//foo/;/../..//bar
+[mid_paths] http://127.0.0.1:8000//foo/;/../../bar
+[mid_paths] http://127.0.0.1:8000//foo/;/.././../bar
+[mid_paths] http://127.0.0.1:8000//foo/;/../.;/../bar
+[mid_paths] http://127.0.0.1:8000//foo/;/..//%2e%2e/bar
+[mid_paths] http://127.0.0.1:8000//foo/;/..//%2fbar
+[mid_paths] http://127.0.0.1:8000//foo/;/..//../bar
+[mid_paths] http://127.0.0.1:8000//foo/;/..///bar
+[mid_paths] http://127.0.0.1:8000//foo/;/..//bar
+[mid_paths] http://127.0.0.1:8000//foo/;/../;/../bar
+[mid_paths] http://127.0.0.1:8000//foo/;/../;/bar
+[mid_paths] http://127.0.0.1:8000//foo/;/../bar
+[mid_paths] http://127.0.0.1:8000//foo/;/..;bar
+[mid_paths] http://127.0.0.1:8000//foo/;/..bar
+[mid_paths] http://127.0.0.1:8000//foo/;/.;.bar
+[mid_paths] http://127.0.0.1:8000//foo/;//%2f../bar
+[mid_paths] http://127.0.0.1:8000//foo/;//../../bar
+[mid_paths] http://127.0.0.1:8000//foo/;//..bar
+[mid_paths] http://127.0.0.1:8000//foo/;///..//bar
+[mid_paths] http://127.0.0.1:8000//foo/;///../bar
+[mid_paths] http://127.0.0.1:8000//foo/;///..bar
+[mid_paths] http://127.0.0.1:8000//foo/;bar
+[mid_paths] http://127.0.0.1:8000//foo/;x/bar
+[mid_paths] http://127.0.0.1:8000//foo/;x;bar
+[mid_paths] http://127.0.0.1:8000//foo/;xbar
+[mid_paths] http://127.0.0.1:8000//foo/???bar
+[mid_paths] http://127.0.0.1:8000//foo/??bar
+[mid_paths] http://127.0.0.1:8000//foo/?bar
+[mid_paths] http://127.0.0.1:8000//foo/\..\.\bar
+[mid_paths] http://127.0.0.1:8000//foo/bar
+[mid_paths] http://127.0.0.1:8000//x/..//foo/bar
+[mid_paths] http://127.0.0.1:8000//x/../;/foo/bar
+[mid_paths] http://127.0.0.1:8000//x/../foo/bar
+[mid_paths] http://127.0.0.1:8000//x/..;//foo/bar
+[mid_paths] http://127.0.0.1:8000//x/..;/;/foo/bar
+[mid_paths] http://127.0.0.1:8000//x/..;/foo/bar
+[mid_paths] http://127.0.0.1:8000//x//../foo/bar
+[mid_paths] http://127.0.0.1:8000//x//..;/foo/bar
+[mid_paths] http://127.0.0.1:8000//x/;/../foo/bar
+[mid_paths] http://127.0.0.1:8000//x/;/..;/foo/bar
+[mid_paths] http://127.0.0.1:8000/;%09..;foo/bar
+[mid_paths] http://127.0.0.1:8000/;%09..foo/bar
+[mid_paths] http://127.0.0.1:8000/;%09;foo/bar
+[mid_paths] http://127.0.0.1:8000/;%09foo/bar
+[mid_paths] http://127.0.0.1:8000/;%2f%2e%2e%2f%2e%2e%2f%2ffoo/bar
+[mid_paths] http://127.0.0.1:8000/;%2f%2e%2efoo/bar
+[mid_paths] http://127.0.0.1:8000/;%2f%2f/../foo/bar
+[mid_paths] http://127.0.0.1:8000/;%2f..%2f%2e%2e%2f%2ffoo/bar
+[mid_paths] http://127.0.0.1:8000/;%2f..%2f..%2f%2ffoo/bar
+[mid_paths] http://127.0.0.1:8000/;%2f..%2f/..%2ffoo/bar
+[mid_paths] http://127.0.0.1:8000/;%2f..%2f/../foo/bar
+[mid_paths] http://127.0.0.1:8000/;%2f..%2f/foo/bar
+[mid_paths] http://127.0.0.1:8000/;%2f../%2f..%2ffoo/bar
+[mid_paths] http://127.0.0.1:8000/;%2f../%2f../foo/bar
+[mid_paths] http://127.0.0.1:8000/;%2f..//..%2ffoo/bar
+[mid_paths] http://127.0.0.1:8000/;%2f..//../foo/bar
+[mid_paths] http://127.0.0.1:8000/;%2f..///;foo/bar
+[mid_paths] http://127.0.0.1:8000/;%2f..///foo/bar
+[mid_paths] http://127.0.0.1:8000/;%2f..//;/;foo/bar
+[mid_paths] http://127.0.0.1:8000/;%2f..//;/foo/bar
+[mid_paths] http://127.0.0.1:8000/;%2f../;//foo/bar
+[mid_paths] http://127.0.0.1:8000/;%2f../;/;/;foo/bar
+[mid_paths] http://127.0.0.1:8000/;%2f../;/;/foo/bar
+[mid_paths] http://127.0.0.1:8000/;%2f..;///foo/bar
+[mid_paths] http://127.0.0.1:8000/;%2f..;//;/foo/bar
+[mid_paths] http://127.0.0.1:8000/;%2f..;/;//foo/bar
+[mid_paths] http://127.0.0.1:8000/;%2f..foo/bar
+[mid_paths] http://127.0.0.1:8000/;%2f/%2f../foo/bar
+[mid_paths] http://127.0.0.1:8000/;%2f//..%2ffoo/bar
+[mid_paths] http://127.0.0.1:8000/;%2f//../foo/bar
+[mid_paths] http://127.0.0.1:8000/;%2f//..;/foo/bar
+[mid_paths] http://127.0.0.1:8000/;%2f/;/../foo/bar
+[mid_paths] http://127.0.0.1:8000/;%2f/;/..;/foo/bar
+[mid_paths] http://127.0.0.1:8000/;%2f;//../foo/bar
+[mid_paths] http://127.0.0.1:8000/;%2f;/;/..;/foo/bar
+[mid_paths] http://127.0.0.1:8000/;/%2e%2e%2f%2ffoo/bar
+[mid_paths] http://127.0.0.1:8000/;/%2e%2e%2f/foo/bar
+[mid_paths] http://127.0.0.1:8000/;/%2e%2e/foo/bar
+[mid_paths] http://127.0.0.1:8000/;/%2e%2efoo/bar
+[mid_paths] http://127.0.0.1:8000/;/%2e.foo/bar
+[mid_paths] http://127.0.0.1:8000/;/%2f%2f../foo/bar
+[mid_paths] http://127.0.0.1:8000/;/%2f/..%2ffoo/bar
+[mid_paths] http://127.0.0.1:8000/;/%2f/../foo/bar
+[mid_paths] http://127.0.0.1:8000/;/.%2e/%2e%2e/%2ffoo/bar
+[mid_paths] http://127.0.0.1:8000/;/.%2efoo/bar
+[mid_paths] http://127.0.0.1:8000/;/..%2f%2f../foo/bar
+[mid_paths] http://127.0.0.1:8000/;/..%2f..%2ffoo/bar
+[mid_paths] http://127.0.0.1:8000/;/..%2f//foo/bar
+[mid_paths] http://127.0.0.1:8000/;/..%2f/foo/bar
+[mid_paths] http://127.0.0.1:8000/;/..%2ffoo/bar
+[mid_paths] http://127.0.0.1:8000/;/../%2f/foo/bar
+[mid_paths] http://127.0.0.1:8000/;/../..//foo/bar
+[mid_paths] http://127.0.0.1:8000/;/../../foo/bar
+[mid_paths] http://127.0.0.1:8000/;/.././../foo/bar
+[mid_paths] http://127.0.0.1:8000/;/../.;/../foo/bar
+[mid_paths] http://127.0.0.1:8000/;/..//%2e%2e/foo/bar
+[mid_paths] http://127.0.0.1:8000/;/..//%2ffoo/bar
+[mid_paths] http://127.0.0.1:8000/;/..//../foo/bar
+[mid_paths] http://127.0.0.1:8000/;/..///foo/bar
+[mid_paths] http://127.0.0.1:8000/;/..//foo/bar
+[mid_paths] http://127.0.0.1:8000/;/../;/../foo/bar
+[mid_paths] http://127.0.0.1:8000/;/../;/foo/bar
+[mid_paths] http://127.0.0.1:8000/;/../foo/bar
+[mid_paths] http://127.0.0.1:8000/;/..;foo/bar
+[mid_paths] http://127.0.0.1:8000/;/..foo/bar
+[mid_paths] http://127.0.0.1:8000/;/.;.foo/bar
+[mid_paths] http://127.0.0.1:8000/;//%2f../foo/bar
+[mid_paths] http://127.0.0.1:8000/;//../../foo/bar
+[mid_paths] http://127.0.0.1:8000/;//..foo/bar
+[mid_paths] http://127.0.0.1:8000/;///..//foo/bar
+[mid_paths] http://127.0.0.1:8000/;///../foo/bar
+[mid_paths] http://127.0.0.1:8000/;///..foo/bar
+[mid_paths] http://127.0.0.1:8000/;foo/bar
+[mid_paths] http://127.0.0.1:8000/;x/foo/bar
+[mid_paths] http://127.0.0.1:8000/;x;foo/bar
+[mid_paths] http://127.0.0.1:8000/;xfoo/bar
+[mid_paths] http://127.0.0.1:8000/???foo/bar
+[mid_paths] http://127.0.0.1:8000/??foo/bar
+[mid_paths] http://127.0.0.1:8000/?foo/bar
+[mid_paths] http://127.0.0.1:8000/\..\.\foo/bar
+[mid_paths] http://127.0.0.1:8000/foo/#?bar
+[mid_paths] http://127.0.0.1:8000/foo/#bar
+[mid_paths] http://127.0.0.1:8000/foo/%09%3bbar
+[mid_paths] http://127.0.0.1:8000/foo/%09..bar
+[mid_paths] http://127.0.0.1:8000/foo/%09;bar
+[mid_paths] http://127.0.0.1:8000/foo/%09bar
+[mid_paths] http://127.0.0.1:8000/foo/%20/bar
+[mid_paths] http://127.0.0.1:8000/foo/%20bar
+[mid_paths] http://127.0.0.1:8000/foo/%23%3fbar
+[mid_paths] http://127.0.0.1:8000/foo/%23bar
+[mid_paths] http://127.0.0.1:8000/foo/%252f%252fbar
+[mid_paths] http://127.0.0.1:8000/foo/%252f/bar
+[mid_paths] http://127.0.0.1:8000/foo/%26bar
+[mid_paths] http://127.0.0.1:8000/foo/%2e%2e%2fbar
+[mid_paths] http://127.0.0.1:8000/foo/%2e%2e/bar
+[mid_paths] http://127.0.0.1:8000/foo/%2e%2ebar
+[mid_paths] http://127.0.0.1:8000/foo/%2e/bar
+[mid_paths] http://127.0.0.1:8000/foo/%2ebar
+[mid_paths] http://127.0.0.1:8000/foo/%2f%20%23bar
+[mid_paths] http://127.0.0.1:8000/foo/%2f%23bar
+[mid_paths] http://127.0.0.1:8000/foo/%2f%2fbar
+[mid_paths] http://127.0.0.1:8000/foo/%2f%3b%2f%2fbar
+[mid_paths] http://127.0.0.1:8000/foo/%2f%3b%2fbar
+[mid_paths] http://127.0.0.1:8000/foo/%2f%3f/bar
+[mid_paths] http://127.0.0.1:8000/foo/%2f%3fbar
+[mid_paths] http://127.0.0.1:8000/foo/%2f/bar
+[mid_paths] http://127.0.0.1:8000/foo/%2fbar
+[mid_paths] http://127.0.0.1:8000/foo/%3b%09bar
+[mid_paths] http://127.0.0.1:8000/foo/%3b%2f%2e%2e%2f%2e%2e%2f%2fbar
+[mid_paths] http://127.0.0.1:8000/foo/%3b%2f%2e%2ebar
+[mid_paths] http://127.0.0.1:8000/foo/%3b%2f%2e.bar
+[mid_paths] http://127.0.0.1:8000/foo/%3b%2f..bar
+[mid_paths] http://127.0.0.1:8000/foo/%3b/%2e%2e/..%2f%2fbar
+[mid_paths] http://127.0.0.1:8000/foo/%3b/%2e.bar
+[mid_paths] http://127.0.0.1:8000/foo/%3b/%2f%2f../bar
+[mid_paths] http://127.0.0.1:8000/foo/%3b/..bar
+[mid_paths] http://127.0.0.1:8000/foo/%3b//%2f../bar
+[mid_paths] http://127.0.0.1:8000/foo/%3bbar
+[mid_paths] http://127.0.0.1:8000/foo/%3f%23bar
+[mid_paths] http://127.0.0.1:8000/foo/%3f%3fbar
+[mid_paths] http://127.0.0.1:8000/foo/%3fbar
+[mid_paths] http://127.0.0.1:8000/foo/%bar
+[mid_paths] http://127.0.0.1:8000/foo/&bar
+[mid_paths] http://127.0.0.1:8000/foo/.%2e/bar
+[mid_paths] http://127.0.0.1:8000/foo/..%00/;bar
+[mid_paths] http://127.0.0.1:8000/foo/..%00/bar
+[mid_paths] http://127.0.0.1:8000/foo/..%00;/bar
+[mid_paths] http://127.0.0.1:8000/foo/..%09bar
+[mid_paths] http://127.0.0.1:8000/foo/..%0d/;bar
+[mid_paths] http://127.0.0.1:8000/foo/..%0d/bar
+[mid_paths] http://127.0.0.1:8000/foo/..%0d;/bar
+[mid_paths] http://127.0.0.1:8000/foo/..%2fbar
+[mid_paths] http://127.0.0.1:8000/foo/..%3Bbar
+[mid_paths] http://127.0.0.1:8000/foo/..%5c/bar
+[mid_paths] http://127.0.0.1:8000/foo/..%5cbar
+[mid_paths] http://127.0.0.1:8000/foo/..%ff/;bar
+[mid_paths] http://127.0.0.1:8000/foo/..%ff;/bar
+[mid_paths] http://127.0.0.1:8000/foo/..%ffbar
+[mid_paths] http://127.0.0.1:8000/foo/.././bar
+[mid_paths] http://127.0.0.1:8000/foo/../bar
+[mid_paths] http://127.0.0.1:8000/foo/..;%00/bar
+[mid_paths] http://127.0.0.1:8000/foo/..;%0d/bar
+[mid_paths] http://127.0.0.1:8000/foo/..;%ff/bar
+[mid_paths] http://127.0.0.1:8000/foo/..;/bar
+[mid_paths] http://127.0.0.1:8000/foo/..;\;bar
+[mid_paths] http://127.0.0.1:8000/foo/..;\\bar
+[mid_paths] http://127.0.0.1:8000/foo/..;bar
+[mid_paths] http://127.0.0.1:8000/foo/..\;bar
+[mid_paths] http://127.0.0.1:8000/foo/..\\bar
+[mid_paths] http://127.0.0.1:8000/foo/..bar
+[mid_paths] http://127.0.0.1:8000/foo/./.bar
+[mid_paths] http://127.0.0.1:8000/foo/.//./bar
+[mid_paths] http://127.0.0.1:8000/foo/./bar
+[mid_paths] http://127.0.0.1:8000/foo/.;/bar
+[mid_paths] http://127.0.0.1:8000/foo/.htmlbar
+[mid_paths] http://127.0.0.1:8000/foo/.jsonbar
+[mid_paths] http://127.0.0.1:8000/foo//%20#bar
+[mid_paths] http://127.0.0.1:8000/foo//%20%20/bar
+[mid_paths] http://127.0.0.1:8000/foo//%20%23bar
+[mid_paths] http://127.0.0.1:8000/foo//%252e%252e%252f/bar
+[mid_paths] http://127.0.0.1:8000/foo//%252e%252e%253b/bar
+[mid_paths] http://127.0.0.1:8000/foo//%252e%252f/bar
+[mid_paths] http://127.0.0.1:8000/foo//%252e%253b/bar
+[mid_paths] http://127.0.0.1:8000/foo//%252e/bar
+[mid_paths] http://127.0.0.1:8000/foo//%252fbar
+[mid_paths] http://127.0.0.1:8000/foo//%2e%2e%3b/bar
+[mid_paths] http://127.0.0.1:8000/foo//%2e%2e/bar
+[mid_paths] http://127.0.0.1:8000/foo//%2e%2ebar
+[mid_paths] http://127.0.0.1:8000/foo//%2e%2f/bar
+[mid_paths] http://127.0.0.1:8000/foo//%2e%3b//bar
+[mid_paths] http://127.0.0.1:8000/foo//%2e%3b/bar
+[mid_paths] http://127.0.0.1:8000/foo//%2e//bar
+[mid_paths] http://127.0.0.1:8000/foo//%2e/bar
+[mid_paths] http://127.0.0.1:8000/foo//%2fbar
+[mid_paths] http://127.0.0.1:8000/foo//%3b/bar
+[mid_paths] http://127.0.0.1:8000/foo//*/bar
+[mid_paths] http://127.0.0.1:8000/foo//*bar
+[mid_paths] http://127.0.0.1:8000/foo//..%2f..%2f..%2fbar
+[mid_paths] http://127.0.0.1:8000/foo//..%2f..%2fbar
+[mid_paths] http://127.0.0.1:8000/foo//..%2fbar
+[mid_paths] http://127.0.0.1:8000/foo//../../..//bar
+[mid_paths] http://127.0.0.1:8000/foo//../../../bar
+[mid_paths] http://127.0.0.1:8000/foo//../..//../bar
+[mid_paths] http://127.0.0.1:8000/foo//../..//bar
+[mid_paths] http://127.0.0.1:8000/foo//../../bar
+[mid_paths] http://127.0.0.1:8000/foo//../..;/bar
+[mid_paths] http://127.0.0.1:8000/foo//.././../bar
+[mid_paths] http://127.0.0.1:8000/foo//../.;/../bar
+[mid_paths] http://127.0.0.1:8000/foo//..//../../bar
+[mid_paths] http://127.0.0.1:8000/foo//..//../bar
+[mid_paths] http://127.0.0.1:8000/foo//..//..;/bar
+[mid_paths] http://127.0.0.1:8000/foo//..//bar
+[mid_paths] http://127.0.0.1:8000/foo//../;/../bar
+[mid_paths] http://127.0.0.1:8000/foo//../;/bar
+[mid_paths] http://127.0.0.1:8000/foo//../bar
+[mid_paths] http://127.0.0.1:8000/foo//..;%2f..;%2f..;%2fbar
+[mid_paths] http://127.0.0.1:8000/foo//..;%2f..;%2fbar
+[mid_paths] http://127.0.0.1:8000/foo//..;%2fbar
+[mid_paths] http://127.0.0.1:8000/foo//..;/../bar
+[mid_paths] http://127.0.0.1:8000/foo//..;/..;/bar
+[mid_paths] http://127.0.0.1:8000/foo//..;//../bar
+[mid_paths] http://127.0.0.1:8000/foo//..;//..;/bar
+[mid_paths] http://127.0.0.1:8000/foo//..;//bar
+[mid_paths] http://127.0.0.1:8000/foo//..;/;/..;/bar
+[mid_paths] http://127.0.0.1:8000/foo//..;/;/bar
+[mid_paths] http://127.0.0.1:8000/foo//..;/bar
+[mid_paths] http://127.0.0.1:8000/foo//..bar
+[mid_paths] http://127.0.0.1:8000/foo//.//bar
+[mid_paths] http://127.0.0.1:8000/foo//./bar
+[mid_paths] http://127.0.0.1:8000/foo//.;//bar
+[mid_paths] http://127.0.0.1:8000/foo//.;/bar
+[mid_paths] http://127.0.0.1:8000/foo//.bar
+[mid_paths] http://127.0.0.1:8000/foo//.randomstringbar
+[mid_paths] http://127.0.0.1:8000/foo///../../bar
+[mid_paths] http://127.0.0.1:8000/foo///..;bar
+[mid_paths] http://127.0.0.1:8000/foo///..bar
+[mid_paths] http://127.0.0.1:8000/foo///./bar
+[mid_paths] http://127.0.0.1:8000/foo///.;/bar
+[mid_paths] http://127.0.0.1:8000/foo///.bar
+[mid_paths] http://127.0.0.1:8000/foo////..//bar
+[mid_paths] http://127.0.0.1:8000/foo////../bar
+[mid_paths] http://127.0.0.1:8000/foo////..;//bar
+[mid_paths] http://127.0.0.1:8000/foo////..;/bar
+[mid_paths] http://127.0.0.1:8000/foo////..;bar
+[mid_paths] http://127.0.0.1:8000/foo////..bar
+[mid_paths] http://127.0.0.1:8000/foo/////bar
+[mid_paths] http://127.0.0.1:8000/foo///;/bar
+[mid_paths] http://127.0.0.1:8000/foo///?anythingbar
+[mid_paths] http://127.0.0.1:8000/foo///bar
+[mid_paths] http://127.0.0.1:8000/foo//;//bar
+[mid_paths] http://127.0.0.1:8000/foo//;/bar
+[mid_paths] http://127.0.0.1:8000/foo//;x/bar
+[mid_paths] http://127.0.0.1:8000/foo//;xbar
+[mid_paths] http://127.0.0.1:8000/foo//bar
+[mid_paths] http://127.0.0.1:8000/foo//x/..//bar
+[mid_paths] http://127.0.0.1:8000/foo//x/../;/bar
+[mid_paths] http://127.0.0.1:8000/foo//x/../bar
+[mid_paths] http://127.0.0.1:8000/foo//x/..;//bar
+[mid_paths] http://127.0.0.1:8000/foo//x/..;/;/bar
+[mid_paths] http://127.0.0.1:8000/foo//x/..;/bar
+[mid_paths] http://127.0.0.1:8000/foo//x//../bar
+[mid_paths] http://127.0.0.1:8000/foo//x//..;/bar
+[mid_paths] http://127.0.0.1:8000/foo//x/;/../bar
+[mid_paths] http://127.0.0.1:8000/foo//x/;/..;/bar
+[mid_paths] http://127.0.0.1:8000/foo/;%09..;bar
+[mid_paths] http://127.0.0.1:8000/foo/;%09..bar
+[mid_paths] http://127.0.0.1:8000/foo/;%09;bar
+[mid_paths] http://127.0.0.1:8000/foo/;%09bar
+[mid_paths] http://127.0.0.1:8000/foo/;%2f%2e%2e%2f%2e%2e%2f%2fbar
+[mid_paths] http://127.0.0.1:8000/foo/;%2f%2e%2ebar
+[mid_paths] http://127.0.0.1:8000/foo/;%2f%2f/../bar
+[mid_paths] http://127.0.0.1:8000/foo/;%2f..%2f%2e%2e%2f%2fbar
+[mid_paths] http://127.0.0.1:8000/foo/;%2f..%2f..%2f%2fbar
+[mid_paths] http://127.0.0.1:8000/foo/;%2f..%2f/..%2fbar
+[mid_paths] http://127.0.0.1:8000/foo/;%2f..%2f/../bar
+[mid_paths] http://127.0.0.1:8000/foo/;%2f..%2f/bar
+[mid_paths] http://127.0.0.1:8000/foo/;%2f../%2f..%2fbar
+[mid_paths] http://127.0.0.1:8000/foo/;%2f../%2f../bar
+[mid_paths] http://127.0.0.1:8000/foo/;%2f..//..%2fbar
+[mid_paths] http://127.0.0.1:8000/foo/;%2f..//../bar
+[mid_paths] http://127.0.0.1:8000/foo/;%2f..///;bar
+[mid_paths] http://127.0.0.1:8000/foo/;%2f..///bar
+[mid_paths] http://127.0.0.1:8000/foo/;%2f..//;/;bar
+[mid_paths] http://127.0.0.1:8000/foo/;%2f..//;/bar
+[mid_paths] http://127.0.0.1:8000/foo/;%2f../;//bar
+[mid_paths] http://127.0.0.1:8000/foo/;%2f../;/;/;bar
+[mid_paths] http://127.0.0.1:8000/foo/;%2f../;/;/bar
+[mid_paths] http://127.0.0.1:8000/foo/;%2f..;///bar
+[mid_paths] http://127.0.0.1:8000/foo/;%2f..;//;/bar
+[mid_paths] http://127.0.0.1:8000/foo/;%2f..;/;//bar
+[mid_paths] http://127.0.0.1:8000/foo/;%2f..bar
+[mid_paths] http://127.0.0.1:8000/foo/;%2f/%2f../bar
+[mid_paths] http://127.0.0.1:8000/foo/;%2f//..%2fbar
+[mid_paths] http://127.0.0.1:8000/foo/;%2f//../bar
+[mid_paths] http://127.0.0.1:8000/foo/;%2f//..;/bar
+[mid_paths] http://127.0.0.1:8000/foo/;%2f/;/../bar
+[mid_paths] http://127.0.0.1:8000/foo/;%2f/;/..;/bar
+[mid_paths] http://127.0.0.1:8000/foo/;%2f;//../bar
+[mid_paths] http://127.0.0.1:8000/foo/;%2f;/;/..;/bar
+[mid_paths] http://127.0.0.1:8000/foo/;/%2e%2e%2f%2fbar
+[mid_paths] http://127.0.0.1:8000/foo/;/%2e%2e%2f/bar
+[mid_paths] http://127.0.0.1:8000/foo/;/%2e%2e/bar
+[mid_paths] http://127.0.0.1:8000/foo/;/%2e%2ebar
+[mid_paths] http://127.0.0.1:8000/foo/;/%2e.bar
+[mid_paths] http://127.0.0.1:8000/foo/;/%2f%2f../bar
+[mid_paths] http://127.0.0.1:8000/foo/;/%2f/..%2fbar
+[mid_paths] http://127.0.0.1:8000/foo/;/%2f/../bar
+[mid_paths] http://127.0.0.1:8000/foo/;/.%2e/%2e%2e/%2fbar
+[mid_paths] http://127.0.0.1:8000/foo/;/.%2ebar
+[mid_paths] http://127.0.0.1:8000/foo/;/..%2f%2f../bar
+[mid_paths] http://127.0.0.1:8000/foo/;/..%2f..%2fbar
+[mid_paths] http://127.0.0.1:8000/foo/;/..%2f//bar
+[mid_paths] http://127.0.0.1:8000/foo/;/..%2f/bar
+[mid_paths] http://127.0.0.1:8000/foo/;/..%2fbar
+[mid_paths] http://127.0.0.1:8000/foo/;/../%2f/bar
+[mid_paths] http://127.0.0.1:8000/foo/;/../..//bar
+[mid_paths] http://127.0.0.1:8000/foo/;/../../bar
+[mid_paths] http://127.0.0.1:8000/foo/;/.././../bar
+[mid_paths] http://127.0.0.1:8000/foo/;/../.;/../bar
+[mid_paths] http://127.0.0.1:8000/foo/;/..//%2e%2e/bar
+[mid_paths] http://127.0.0.1:8000/foo/;/..//%2fbar
+[mid_paths] http://127.0.0.1:8000/foo/;/..//../bar
+[mid_paths] http://127.0.0.1:8000/foo/;/..///bar
+[mid_paths] http://127.0.0.1:8000/foo/;/..//bar
+[mid_paths] http://127.0.0.1:8000/foo/;/../;/../bar
+[mid_paths] http://127.0.0.1:8000/foo/;/../;/bar
+[mid_paths] http://127.0.0.1:8000/foo/;/../bar
+[mid_paths] http://127.0.0.1:8000/foo/;/..;bar
+[mid_paths] http://127.0.0.1:8000/foo/;/..bar
+[mid_paths] http://127.0.0.1:8000/foo/;/.;.bar
+[mid_paths] http://127.0.0.1:8000/foo/;//%2f../bar
+[mid_paths] http://127.0.0.1:8000/foo/;//../../bar
+[mid_paths] http://127.0.0.1:8000/foo/;//..bar
+[mid_paths] http://127.0.0.1:8000/foo/;///..//bar
+[mid_paths] http://127.0.0.1:8000/foo/;///../bar
+[mid_paths] http://127.0.0.1:8000/foo/;///..bar
+[mid_paths] http://127.0.0.1:8000/foo/;bar
+[mid_paths] http://127.0.0.1:8000/foo/;x/bar
+[mid_paths] http://127.0.0.1:8000/foo/;x;bar
+[mid_paths] http://127.0.0.1:8000/foo/;xbar
+[mid_paths] http://127.0.0.1:8000/foo/???bar
+[mid_paths] http://127.0.0.1:8000/foo/??bar
+[mid_paths] http://127.0.0.1:8000/foo/?bar
+[mid_paths] http://127.0.0.1:8000/foo/\..\.\bar
+[original_request] http://127.0.0.1:8000/foo/bar


### PR DESCRIPTION
This pull request solves the awful performance problem at program start-up, when generating curl requests. 

After investigation and a little profiling, it seems that the problem comes from the storage in list of generated `curl_items`:

```
for header in xxx:
    for internal in yyy:
    …
        if item not in self.curl_items:
            self.curl_items.append(item)
    …
````

To check if a **CurlItem** object is already in the list, the **CurlItem** `__eq__()` function is called to compare the attributes of two objects, returned in a tupple by the `__attrs()` method:

```
def __attrs(self):
    return (self.target_url, self.target_ip, self.bypass_mode, self.curl_base_options,
                  self.request_curl_cmd, self.response_raw_output)

def __eq__(self, other) -> bool:
    return isinstance(other, self.__class__) and self.__attrs() == other.__attrs()
```

For each item added to the curl_items list, the inserted object is compared to all existing items in the list (`if item not in self.curl_items`). So, to generate all payloads, `__eq()__` is called **13001247** times, and `__attr()` **26002494** times. Damn!

![image](https://user-images.githubusercontent.com/15103453/194204316-d802473a-e821-43f4-9295-c62b29607ae1.png)

```bash
 time ./bypass_url_parse.py --dump-payloads -u http://127.0.0.1:8000/foo/bar -v > /dev/null

real    0m25.489s
user    0m25.318s
sys     0m0.104s
```

It is possible (first commit) to refactor the `__eq__()` function to remove the unnecessary call to `__eq()` using the built-in dictionary `__dict__` which contains everything required to compare two objects:

```
def __eq__(self, other: any) -> bool:
    return other.__class__ == CurlItem and self.__dict__ == other.__dict__
```
With **26002494** of less `tupple`, the code is already faster:

![image](https://user-images.githubusercontent.com/15103453/194204429-7255dedd-ceb0-4902-9f72-71726230fb79.png)

```bash
 time ./bypass_url_parse.py --dump-payloads -u http://127.0.0.1:8000/foo/bar -v > /dev/null

real    0m8.741s
user    0m8.662s
sys     0m0.052s
```

Not enough, the best solution is to abandon the `list` in favor of a `set`, much better adapted here. Sets uses the `__hash()__` function to get a unique collection of values and compare two objects.

Initial **CurlItem** `__hash__()` function looks like:

```
def __hash__(self) -> int:
    return hash(self.__attrs())
```
No, not again __attr() :-( So we move to:

```
def __hash__(self) -> int:
    return hash(str(self.__dict__))
```

And the result is without appeal:

![image](https://user-images.githubusercontent.com/15103453/194204483-4d2689b7-d43a-40d6-93ed-b835c557df5e.png)

```bash
 time ./bypass_url_parse.py --dump-payloads -u http://127.0.0.1:8000/foo/bar -v > /dev/null

real    0m0.364s
user    0m0.315s
sys     0m0.048s
```